### PR TITLE
체크포인트 마커 로딩후 이탈시에도 뒤늦게 로딩 완료된 마커가 표시되던 문제 수정

### DIFF
--- a/presentation/src/main/java/com/wheretogo/presentation/feature/map/DriveMapOverlayService.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/map/DriveMapOverlayService.kt
@@ -145,4 +145,16 @@ class DriveMapOverlayService @Inject constructor(private val overlayStore: Naver
             overlayStore.remove(it)
         }
     }
+
+    fun clearCheckPoint(){
+        val checkPointIdGroup  = _overlays.mapNotNull {
+            val mapOverlay = it.value
+            if(mapOverlay is MapOverlay.MarkerContainer){
+                if(mapOverlay.type == MarkerType.CHECKPOINT)
+                   return@mapNotNull it.value.id
+            }
+            null
+        }
+        removeCheckPoint(checkPointIdGroup)
+    }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/naver/NaverMapOverlayStore.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/naver/NaverMapOverlayStore.kt
@@ -36,11 +36,14 @@ class NaverMapOverlayStore @Inject constructor() {
 
     fun getOrCreatePath(pathInfo: PathInfo): PathOverlay? {
         return runCatching {
+            if (pathInfo.points.size < 2)
+                return null
+
             paths.getOrPut(pathInfo.contentId) {
                 pathInfo.toNaverPath()
             }.apply { coords = pathInfo.points.toNaver() }
         }.onFailure {
-            Log.d("tst_","fail ${pathInfo.contentId}-${it.message}")
+            Log.d("tst_", "fail ${pathInfo.contentId}-${it.message}")
         }.getOrNull()
     }
 
@@ -58,9 +61,12 @@ class NaverMapOverlayStore @Inject constructor() {
         return Marker().apply {
             markerInfo.position?.let { position = it.toNaver() }
             markerInfo.caption?.let { captionText= it}
+            //마커가 아이콘
             markerInfo.iconRes?.let { res->
                 icon = OverlayImage.fromResource(res)
             }
+
+            //마커가 사진
             markerInfo.iconPath?.let { path ->
                 val bitmap = BitmapFactory.decodeFile(path)
                 val overlayImage = OverlayImage.fromBitmap(

--- a/presentation/src/main/java/com/wheretogo/presentation/model/MapOverlay.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/MapOverlay.kt
@@ -6,7 +6,7 @@ import com.wheretogo.presentation.MarkerType
 import com.wheretogo.presentation.PathType
 
 sealed class MapOverlay(
-    open val id: String
+    open val id: String // 컨텐츠 ID
 ) {
     data class MarkerContainer(
         override val id: String,


### PR DESCRIPTION
- 체크포인트가 표시될때 해당 코스가 포커스 되어있을때만 표시
- 잘못 표시된 체크포인트 클릭시 모든 체크포인트 지도위에서 삭제