### PR TITLE
개발용  서버(staging), 앱 도입

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,20 +50,24 @@ android {
     }
     buildTypes {
         debug {
+            applicationIdSuffix = ".debug"
             buildConfigField( "Boolean", "CRASHLYTICS", "false")
+            buildConfigField("String",  "GOOGLE_WEB_CLIENT_ID_KEY", getLocalProperties("googleStagingWebClientId"))
         }
         create("qa") {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-qa"
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            versionNameSuffix = "-qa"
             signingConfig = signingConfigs.getByName("debug")
             isDebuggable = true
 
             buildConfigField( "Boolean", "CRASHLYTICS", "false")
+            buildConfigField("String","GOOGLE_WEB_CLIENT_ID_KEY", getLocalProperties("googleStagingWebClientId"))
         }
 
         release {
@@ -76,6 +80,7 @@ android {
             signingConfig = signingConfigs.getByName("release")
 
             buildConfigField( "Boolean", "CRASHLYTICS", "true")
+            buildConfigField("String", "GOOGLE_WEB_CLIENT_ID_KEY", getLocalProperties("googleWebClientId"))
         }
     }
     compileOptions {

--- a/app/src/main/java/com/dhkim139/wheretogo/di/KeyModule.kt
+++ b/app/src/main/java/com/dhkim139/wheretogo/di/KeyModule.kt
@@ -1,7 +1,7 @@
 package com.dhkim139.wheretogo.di
 
 import com.wheretogo.data.model.key.AppKey
-import com.wheretogo.presentation.BuildConfig
+import com.dhkim139.wheretogo.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/data/src/main/java/com/wheretogo/data/DataPolicy.kt
+++ b/data/src/main/java/com/wheretogo/data/DataPolicy.kt
@@ -11,6 +11,7 @@ const val NAVER_OPEN_API_APIGW_URL = "https://naveropenapi.apigw.ntruss.com"
 const val NAVER_MAPS_NTRUSS_APIGW_URL = "https://maps.apigw.ntruss.com/"
 const val NAVER_OPEN_API_URL = "https://openapi.naver.com/"
 const val FIREBASE_CLOUD_API_URL = "https://asia-northeast3-where-to-go-35813.cloudfunctions.net/"
+const val FIREBASE_CLOUD_STAGING_API_URL = "https://asia-northeast3-where-to-go-staging.cloudfunctions.net/"
 
 const val DATA_NULL = ""
 const val IMAGE_DOWN_MAX_MB = 10
@@ -100,6 +101,13 @@ fun getDbOption():Int{
     return when(BuildConfig.FIREBASE){
         "RELEASE" ->  1
         else -> 0
+    }
+}
+
+fun firebaseApiUrlByBuild(): String{
+    return when(BuildConfig.FIREBASE){
+        "RELEASE" -> FIREBASE_CLOUD_API_URL
+        else -> FIREBASE_CLOUD_STAGING_API_URL
     }
 }
 

--- a/data/src/main/java/com/wheretogo/data/di/RetrofitClientModule.kt
+++ b/data/src/main/java/com/wheretogo/data/di/RetrofitClientModule.kt
@@ -2,9 +2,9 @@ package com.wheretogo.data.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wheretogo.data.FIREBASE_CLOUD_API_URL
 import com.wheretogo.data.NAVER_MAPS_NTRUSS_APIGW_URL
 import com.wheretogo.data.NAVER_OPEN_API_URL
+import com.wheretogo.data.firebaseApiUrlByBuild
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -70,11 +70,9 @@ object RetrofitClientModule {
     @Named("firebase")
     fun provideFirebaseRetrofit(moshi: Moshi, client: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .addConverterFactory(
-                MoshiConverterFactory.create(moshi)
-            )
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
             .client(client)
-            .baseUrl(FIREBASE_CLOUD_API_URL)
+            .baseUrl(firebaseApiUrlByBuild())
             .build()
     }
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -52,8 +52,6 @@ android {
 
         buildConfigField( "String", "TMAP_APP_KEY", getLocalProperties("tmapApp"))
 
-        buildConfigField( "String", "GOOGLE_WEB_CLIENT_ID_KEY", getLocalProperties("googleWebClientId"))
-
         manifestPlaceholders["adsMobAppId"] = getLocalProperties("adsMobAppId")
     }
     compileOptions {


### PR DESCRIPTION
### 1. 파이어베이스 프로젝트 prod/staging 분리

### 2. 빌드별  프로젝트 연동을 위한 APP 분리 (package + .debug)

개발전용 applicationId 사용하여 새로운 staging 프로젝트 연동 (google-services.json 추가) 

**(build → firebase project)**

release → production

qa, debug → staing

## ✅ 테스트 항목
- [x]  릴리즈 빌드로 prod api 연동 테스트
- [x]  릴리즈 빌드로 로그인 테스트
- [x]  디버그/qa 빌드로 staging api 연동 테스트
- [x]  디버그/qa 빌드로 로그인 테스트