### PR TITLE
firebaseApi 인증 토큰 관리 방식 변경

### DIFF
--- a/app/src/androidTest/java/com/dhkim139/wheretogo/mock/MockAuthRemoteDatasourceImpl.kt
+++ b/app/src/androidTest/java/com/dhkim139/wheretogo/mock/MockAuthRemoteDatasourceImpl.kt
@@ -34,4 +34,8 @@ class MockAuthRemoteDatasourceImpl @Inject constructor(
     override suspend fun deleteUser(): Boolean {
         return true
     }
+
+    override suspend fun getApiToken(isForceRefresh: Boolean): Result<String?> {
+        return Result.success("")
+    }
 }

--- a/app/src/androidTest/java/com/dhkim139/wheretogo/mock/MockUserRemoteDatasourceImpl.kt
+++ b/app/src/androidTest/java/com/dhkim139/wheretogo/mock/MockUserRemoteDatasourceImpl.kt
@@ -12,7 +12,6 @@ import com.wheretogo.data.toRemoteProfilePrivate
 import com.wheretogo.domain.HistoryType
 import com.wheretogo.domain.get
 import com.wheretogo.domain.map
-import com.wheretogo.domain.model.user.ProfilePrivate
 import javax.inject.Inject
 
 class MockUserRemoteDatasourceImpl @Inject constructor(
@@ -58,9 +57,9 @@ class MockUserRemoteDatasourceImpl @Inject constructor(
         userRemoteGroup.remove(uid)
     }
 
-    override suspend fun deleteUser(userId: String, token: String): String {
+    override suspend fun deleteUser(userId: String): Result<String> {
         userRemoteGroup.remove(userId)
-        return ""
+        return Result.success("")
     }
 
     override suspend fun addHistory(uid: String, historyId: String, type: HistoryType) {

--- a/data/src/main/java/com/wheretogo/data/DataPolicy.kt
+++ b/data/src/main/java/com/wheretogo/data/DataPolicy.kt
@@ -97,13 +97,6 @@ fun FireStoreCollections.name(): String {
     }
 }
 
-fun getDbOption():Int{
-    return when(BuildConfig.FIREBASE){
-        "RELEASE" ->  1
-        else -> 0
-    }
-}
-
 fun firebaseApiUrlByBuild(): String{
     return when(BuildConfig.FIREBASE){
         "RELEASE" -> FIREBASE_CLOUD_API_URL

--- a/data/src/main/java/com/wheretogo/data/datasource/AuthRemoteDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/AuthRemoteDatasource.kt
@@ -10,4 +10,6 @@ interface AuthRemoteDatasource {
     suspend fun signOutOnFirebase()
 
     suspend fun deleteUser(): Boolean
+
+    suspend fun getApiToken(isForceRefresh: Boolean): Result<String?>
 }

--- a/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
@@ -18,13 +18,9 @@ interface UserLocalDatasource {
 
     fun getHistoryFlow(type: HistoryType): Flow<HashSet<String>>
 
-    fun getTokenFlow(): Flow<String>
-
     suspend fun setProfile(profile: LocalProfile)
 
     suspend fun setHistory(history: History)
-
-    suspend fun setToken(token:String)
 
     suspend fun clearUser()
 

--- a/data/src/main/java/com/wheretogo/data/datasource/UserRemoteDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/UserRemoteDatasource.kt
@@ -12,7 +12,7 @@ interface UserRemoteDatasource {
     suspend fun getProfilePublicWithMail(hashMail: String): RemoteProfilePublic?
     suspend fun getProfilePrivate(uid: String): RemoteProfilePrivate?
     suspend fun deleteProfile(uid: String)
-    suspend fun deleteUser(userId: String, token: String):String
+    suspend fun deleteUser(userId: String): Result<String>
 
     suspend fun addHistory(uid: String, historyId: String, type: HistoryType)
     suspend fun getHistoryGroup(uid: String, type: HistoryType): Pair<HistoryType, HashSet<String>>

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/UserLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/UserLocalDatasourceImpl.kt
@@ -37,8 +37,6 @@ class UserLocalDatasourceImpl @Inject constructor(
     private val checkpoint = stringSetPreferencesKey("checkpoint_profile")
     private val reportContent = stringSetPreferencesKey("report_content_profile")
 
-    private val firebaseToken = stringPreferencesKey("token_firebase")
-
     override fun isRequestLoginFlow(): Flow<Boolean> {
         return userDataStore.data.map { preferences ->
             preferences[isRequestLoginKey] ?: true
@@ -93,12 +91,6 @@ class UserLocalDatasourceImpl @Inject constructor(
         }
     }
 
-    override fun getTokenFlow(): Flow<String> {
-        return userDataStore.data.map { preferences ->
-            preferences[firebaseToken]?:""
-        }
-    }
-
     override suspend fun setProfile(profile: LocalProfile) {
         userDataStore.edit { preferences ->
             preferences[uid] = profile.uid
@@ -123,16 +115,9 @@ class UserLocalDatasourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun setToken(token:String){
-        userDataStore.edit { preferences ->
-            preferences[firebaseToken] = token
-        }
-    }
-
     override suspend fun clearUser() {
         setProfile(LocalProfile())
         setHistory(History())
-        setToken("")
     }
 
     override fun getProfileFlow(): Flow<LocalProfile> {

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/service/FirebaseApiService.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/service/FirebaseApiService.kt
@@ -1,16 +1,13 @@
 package com.wheretogo.data.datasourceimpl.service
 
-import com.wheretogo.data.model.user.UserDeleteRequest
 import com.wheretogo.data.model.user.UserDeleteResponse
 import retrofit2.Response
-import retrofit2.http.Body
-import retrofit2.http.Header
-import retrofit2.http.POST
+import retrofit2.http.DELETE
+import retrofit2.http.Path
 
 interface FirebaseApiService {
-        @POST("anonymizeAndDeleteUser")
+    @DELETE("api/user/{userId}")
     suspend fun deleteUser(
-        @Body request: UserDeleteRequest,
-        @Header("Authorization") authorization: String
+        @Path("userId") userId:String
     ): Response<UserDeleteResponse>
 }

--- a/data/src/main/java/com/wheretogo/data/di/RetrofitClientModule.kt
+++ b/data/src/main/java/com/wheretogo/data/di/RetrofitClientModule.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.wheretogo.data.NAVER_MAPS_NTRUSS_APIGW_URL
 import com.wheretogo.data.NAVER_OPEN_API_URL
 import com.wheretogo.data.firebaseApiUrlByBuild
+import com.wheretogo.data.network.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,25 +20,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitClientModule {
-
-    @Singleton
-    @Provides
-    fun provideClient(): OkHttpClient {
-        return OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .writeTimeout(10,TimeUnit.SECONDS)
-            .callTimeout(30, TimeUnit.SECONDS)
-            .build()
-    }
-
-    @Singleton
-    @Provides
-    fun provideMoshi(): Moshi {
-        return Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
-    }
 
     @Singleton
     @Provides
@@ -68,11 +50,50 @@ object RetrofitClientModule {
     @Singleton
     @Provides
     @Named("firebase")
-    fun provideFirebaseRetrofit(moshi: Moshi, client: OkHttpClient): Retrofit {
+    fun provideFirebaseApiRetrofit(
+        moshi: Moshi,
+        @Named("authHttp") client: OkHttpClient
+    ): Retrofit {
         return Retrofit.Builder()
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .client(client)
             .baseUrl(firebaseApiUrlByBuild())
+            .build()
+    }
+
+
+    // 레트로핏 유틸
+
+    @Singleton
+    @Provides
+    @Named("authHttp")
+    fun provideAuthHttpClient(authInterceptor: AuthInterceptor): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10,TimeUnit.SECONDS)
+            .callTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(authInterceptor)
+            .build()
+    }
+
+
+    @Singleton
+    @Provides
+    fun provideHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10,TimeUnit.SECONDS)
+            .callTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
             .build()
     }
 }

--- a/data/src/main/java/com/wheretogo/data/network/AuthInterceptor.kt
+++ b/data/src/main/java/com/wheretogo/data/network/AuthInterceptor.kt
@@ -1,0 +1,50 @@
+package com.wheretogo.data.network;
+
+import com.wheretogo.data.datasource.AuthRemoteDatasource
+import com.wheretogo.data.datasource.UserLocalDatasource
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+
+class AuthInterceptor @Inject constructor(
+    private val auth: AuthRemoteDatasource,
+    private val user: UserLocalDatasource
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val authResponse = chain.proceed(chain.request().authRequest())
+
+        if (authResponse.code() != 401) return authResponse
+        authResponse.close()
+
+        // 만료시 재시도
+        val refreshed = runBlocking { refreshToken() }
+        if (!refreshed) {
+            runBlocking { logout() }
+        }
+
+        return chain.proceed(chain.request().authRequest())
+    }
+
+    private fun Request.authRequest(): Request {
+        return newBuilder().apply {
+            val token = runBlocking { getToken() }
+            if (token != null) header("Authorization", "Bearer $token")
+        }.build()
+    }
+
+    private suspend fun getToken(): String? {
+        return auth.getApiToken(false).getOrNull()
+    }
+
+    private suspend fun refreshToken(): Boolean {
+        return auth.getApiToken(true).isSuccess
+    }
+
+    private suspend fun logout() {
+        user.clearUser()
+        user.setRequestLogin(true)
+    }
+}

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/UserRepositoryImpl.kt
@@ -197,7 +197,6 @@ class UserRepositoryImpl @Inject constructor(
                     val newProfile = profile.copy(private = newPrivate.await())
                     val history = async { getRemoteHistory(authProfile.uid).getOrNull() ?: History() }
                     userLocalDatasource.setProfile(newProfile.toLocalProfile())
-                    userLocalDatasource.setToken(authProfile.token)
                     setLocalHistory(history.await())
                     return@coroutineScope profile
                 }
@@ -216,10 +215,8 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun deleteUser(): Result<Unit> {
         return runCatching{
             val uid = userLocalDatasource.getProfileFlow().first().uid
-            val token= userLocalDatasource.getTokenFlow().first()
             check(uid.isNotBlank())
-            check(token.isNotBlank())
-            userRemoteDatasource.deleteUser(uid, token)
+            userRemoteDatasource.deleteUser(uid)
             clearUserCache()
         }
     }


### PR DESCRIPTION
### 1. firebaseApi 인증 토큰을 인터셉터로 관리
### 2. 인증 만료시 갱신추가
### 3. firebase api 주소 변경

## ✅ 테스트 항목
- [x]  만료시 토큰 재발급
- [x]  토큰 재발급 불가시 로그아웃
- [x]  새로운 firebase api 작동 확인