### PR TITLE
계정 삭제 성공후 사용자 프로필이 계속 표시되던 문제 해결

### DIFF
--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/SettingViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/SettingViewModel.kt
@@ -120,11 +120,18 @@ class SettingViewModel @Inject constructor(
             _settingScreenState.update {
                 it.copy(
                     isLoading = true,
-                    isDialog = true
+                    isDialog = true,
                 )
             }
             withContext(Dispatchers.IO) { deleteUserUseCase() }.onFailure {
                 handleError(it)
+            }.onSuccess {
+                _settingScreenState.update {
+                    it.copy(
+                        isProfile = false,
+                        profile = Profile()
+                    )
+                }
             }
         }
         _settingScreenState.update {


### PR DESCRIPTION
### 1. 계정 삭제 후 사용자 프로필 표시 오류
- 계정 삭제 성공시 프로필 상태 초기화

## ✅ 테스트 항목
- [x]  계정 삭제후 프로필이 사라지는지 확인