### PR TITLE
광고 폰트 스케일 및 ui간섭 대응

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,5 +4,7 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="${adsMobAppId}"/>
+        <meta-data android:name="com.google.android.gms.ads.flag.NATIVE_AD_DEBUGGER_ENABLED"
+            android:value="false" />
     </application>
 </manifest>

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
@@ -29,6 +29,7 @@ const val SEARCH_MARKER = "SEARCH_MARKER_ID"
 const val CLEAR_ADDRESS = "CLEAR_ADDRESS"
 const val DEBUG_AD_REFRESH_SIZE = 1
 const val AD_REFRESH_SIZE = 3
+const val AD_MAX_FONT_SCALE = 1.2f
 
 enum class OverlayType {
     SPOT, CHECKPOINT, PATH

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
@@ -154,7 +154,7 @@ fun CourseAddSheetContent(
 
     //SearchBar
     onSearchBarItemClick: (SearchBarItem) -> Unit = {},
-    onSearchBarClick: () -> Unit = {},
+    onSearchBarClick: (Boolean) -> Unit = {},
     onSearchSubmit: (String) -> Unit = {},
     onSearchBarClose: () -> Unit = {},
 

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
@@ -128,7 +128,7 @@ fun DriveScreen(
 
             //Searchbar
             onSearchSubmit = { handleIntent(DriveScreenIntent.SearchSubmit(it)) },
-            onSearchBarClick = { handleIntent(DriveScreenIntent.SearchBarClick) },
+            onSearchBarClick = { handleIntent(DriveScreenIntent.SearchBarClick(it)) },
             onSearchBarItemClick = { handleIntent(DriveScreenIntent.AddressItemClick(it)) },
             onSearchBarClose = { handleIntent(DriveScreenIntent.SearchBarClose) },
 
@@ -196,7 +196,7 @@ fun DriveContent(
 
     //SearchBar
     onSearchBarItemClick: (SearchBarItem) -> Unit = {},
-    onSearchBarClick: () -> Unit = {},
+    onSearchBarClick: (Boolean) -> Unit = {},
     onSearchSubmit: (String) -> Unit = {},
     onSearchBarClose: () -> Unit = {},
 

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/Ads.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/Ads.kt
@@ -1,28 +1,28 @@
 package com.wheretogo.presentation.composable.content
 
-import android.graphics.drawable.Drawable
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,7 +32,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -41,15 +43,19 @@ import androidx.compose.ui.unit.sp
 import com.google.android.gms.ads.nativead.NativeAd
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
+import com.wheretogo.presentation.AD_MAX_FONT_SCALE
 import com.wheretogo.presentation.AdMinSize
 import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.content.ad.LocalNativeAdView
 import com.wheretogo.presentation.composable.content.ad.NativeAdAdvertiserView
 import com.wheretogo.presentation.composable.content.ad.NativeAdBodyView
 import com.wheretogo.presentation.composable.content.ad.NativeAdCallToActionView
 import com.wheretogo.presentation.composable.content.ad.NativeAdChoicesView
 import com.wheretogo.presentation.composable.content.ad.NativeAdHeadlineView
-import com.wheretogo.presentation.composable.content.ad.NativeAdImageView
+import com.wheretogo.presentation.composable.content.ad.NativeAdMediaView
 import com.wheretogo.presentation.composable.content.ad.NativeAdView
+import com.wheretogo.presentation.composable.effect.CardAdEffect
+import com.wheretogo.presentation.feature.FontMaxScale
 import com.wheretogo.presentation.theme.Blue100
 import com.wheretogo.presentation.theme.Blue50
 import com.wheretogo.presentation.theme.Blue500
@@ -62,7 +68,7 @@ import com.wheretogo.presentation.theme.hancomSansFontFamily
 import com.wheretogo.presentation.theme.interBoldFontFamily
 import com.wheretogo.presentation.theme.interFontFamily
 
-data class AdPreview(val headline:String, val image:Int, val body:String, val advertiser:String)
+data class AdPreview(val headline: String, val image: Int, val body: String, val advertiser: String)
 
 val dummy = AdPreview(
     headline = "헤드라인",
@@ -73,66 +79,80 @@ val dummy = AdPreview(
 
 @Preview(widthDp = 800, heightDp = 200, backgroundColor = 0xFF000000L)
 @Composable
-fun RowAdPreview(){
-    Box(modifier = Modifier.padding(5.dp)){
+fun RowAdPreview() {
+    Box(modifier = Modifier.padding(5.dp)) {
         RowAd()
     }
 }
 
 @Preview(widthDp = 400, heightDp = 500)
 @Composable
-fun CardAdPreview(){
-    Box(modifier = Modifier.padding(5.dp)){
+fun CardAdPreview() {
+    Box(modifier = Modifier.padding(5.dp)) {
         CardAd()
     }
 }
 
 // 광고
 @Composable
-fun AdaptiveAd(modifier: Modifier=Modifier, elevation: Dp= 8.dp, nativeAd: NativeAd?){
-    val isPreview = LocalInspectionMode.current
+fun AdaptiveAd(
+    modifier: Modifier = Modifier,
+    elevation: Dp = 8.dp,
+    isCompact: Boolean = false,
+    nativeAd: NativeAd?
+) {
     val adSize = adSize()
 
-
     Box(modifier = modifier) {
-        when(adSize){
+        when (adSize) {
             AdMinSize.Row -> {
-                val height = 95.dp
-                Box(modifier=Modifier.heightIn(min = height)){
-                    when {
-                        isPreview -> RowAd(elevation = elevation, nativeAd = nativeAd)
-                        nativeAd != null -> RowAd(elevation = elevation, nativeAd = nativeAd)
-                        else -> RowAdPlaceholder()
+                when {
+                    isCompact -> { }
+                    nativeAd != null -> {
+                        RowAd(elevation = elevation, nativeAd = nativeAd)
+                    }
+                    else -> {
+                        RowAdPlaceholder()
                     }
                 }
             }
 
             AdMinSize.Card -> {
-                val height = 335.dp
-                Box(modifier=Modifier.heightIn(min = height)){
-                    when {
-                        isPreview -> CardAd(elevation = elevation, nativeAd = nativeAd)
-                        nativeAd != null -> CardAd(elevation = elevation, nativeAd = nativeAd)
-                        else -> CardAdPlaceholder()
+                when {
+                    nativeAd != null -> {
+                        CardAd(
+                            elevation = elevation,
+                            isCompact = isCompact,
+                            nativeAd = nativeAd
+                        )
+                    }
+
+                    else -> {
+                        CardAdPlaceholder()
                     }
                 }
             }
-            else->{}
+
+            else -> {}
         }
     }
 }
 
 @Composable
-fun CardAd(modifier: Modifier = Modifier, elevation: Dp= 8.dp, nativeAd: NativeAd?=null){
+fun CardAd(
+    modifier: Modifier = Modifier,
+    elevation: Dp = 8.dp,
+    isCompact: Boolean = false,
+    nativeAd: NativeAd? = null
+) {
     val isPreview = LocalInspectionMode.current
-    val image = if(isPreview) null else nativeAd?.images?.firstOrNull()?.drawable
-    val headline = if(isPreview) dummy.headline else nativeAd?.headline
-    val body = if(isPreview) dummy.body else nativeAd?.body
-    val advertiser = if(isPreview) dummy.advertiser else nativeAd?.advertiser
+    val headline = if (isPreview) dummy.headline else nativeAd?.headline
+    val body = if (isPreview) dummy.body else nativeAd?.body
+    val advertiser = if (isPreview) dummy.advertiser else nativeAd?.advertiser
 
     Card(
-        modifier = modifier
-            .widthIn(max = 500.dp),
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
         colors = CardColors(
             containerColor = White50,
             contentColor = Color.Black,
@@ -141,62 +161,84 @@ fun CardAd(modifier: Modifier = Modifier, elevation: Dp= 8.dp, nativeAd: NativeA
         ),
         elevation = CardDefaults.cardElevation(elevation)
     ) {
-        NativeAdView(modifier = Modifier.height(IntrinsicSize.Min)) {
+        NativeAdView {
+            var bodyMaxLines by remember { mutableIntStateOf(if (isCompact) 0 else 3) }
+            var tiltLines by remember { mutableIntStateOf(-1) }
+
+            CardAdEffect(nativeAd, isCompact, tiltLines) { maxLine->
+                bodyMaxLines = maxLine
+            }
+
             Column {
+                val contentRatio = nativeAd?.mediaContent?.aspectRatio ?: (16f / 9f)
+                val imageRatio = if (contentRatio > 1.5f) contentRatio else 16f / 9f
                 Box {
                     // 광고 이미지
                     AdImage(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .aspectRatio(16f / 9f), image
+                            .aspectRatio(imageRatio)
                     )
                     // 광고 마크
-                    AdMark(modifier = Modifier.padding(8.dp))
-                    // 광고 초이스
-                    AdChoice(
-                        modifier = Modifier
-                            .align(alignment = Alignment.TopEnd)
-                            .padding(8.dp)
-                    )
+                    AdMark(modifier = Modifier.padding(4.dp))
                 }
                 Column(
                     modifier = Modifier
-                        .padding(horizontal = 12.dp, vertical = 6.dp)
-                        .padding(bottom = 2.dp),
+                        .fillMaxWidth(),
                 ) {
-                    Spacer(Modifier.height(1.dp))
-                    Row {
+                    val hp = 12.dp
+                    Spacer(Modifier.height(4.dp))
+                    Row(modifier = Modifier.padding(horizontal = hp)) {
                         // 헤드라인
-                        AdHeadLine(modifier = Modifier.weight(1f), text = headline)
-                        // 광고주
-                        AdAdvertiser(modifier = Modifier, advertiser)
+                        AdHeadLine(
+                            modifier = Modifier.weight(1f),
+                            text = headline
+                        ) { layout ->
+                            tiltLines = layout.lineCount
+                        }
                     }
 
                     Spacer(Modifier.height(2.dp))
                     // 바디
-                    AdBody(text = body)
-                    Spacer(Modifier.height(4.dp))
+                    if (bodyMaxLines > 0) {
+                        AdBody(
+                            modifier = Modifier
+                                .padding(horizontal = hp),
+                            maxLine = bodyMaxLines,
+                            text = body
+                        )
+                    }
+                    // 광고주
+                    AdAdvertiser(
+                        modifier = Modifier
+                            .padding(horizontal = hp)
+                            .align(Alignment.End), advertiser
+                    )
                     // CTA
-                    AdCta(modifier = Modifier.fillMaxWidth(), nativeAd?.callToAction)
-                    Spacer(Modifier.height(4.dp))
+                    AdCta(
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                            .fillMaxWidth(), nativeAd?.callToAction
+                    )
+                    Spacer(Modifier.height(8.dp))
                 }
             }
         }
+
     }
 }
 
 @Composable
-fun RowAd(modifier: Modifier = Modifier, elevation: Dp = 8.dp, nativeAd: NativeAd? = null){
+fun RowAd(modifier: Modifier = Modifier, elevation: Dp = 8.dp, nativeAd: NativeAd? = null) {
     val isPreview = LocalInspectionMode.current
-    val image = if(isPreview) null else nativeAd?.images?.firstOrNull()?.drawable
-    val headline = if(isPreview) dummy.headline else nativeAd?.headline
-    val body = if(isPreview) dummy.body else nativeAd?.body
-    val advertiser = if(isPreview) dummy.advertiser else nativeAd?.advertiser
+    val headline = if (isPreview) dummy.headline else nativeAd?.headline
+    val body = if (isPreview) dummy.body else nativeAd?.body
+    val advertiser = if (isPreview) dummy.advertiser else nativeAd?.advertiser
 
     Card(
         modifier = modifier
             .fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(4.dp),
         colors = CardColors(
             containerColor = White50,
             contentColor = Color.Black,
@@ -205,45 +247,52 @@ fun RowAd(modifier: Modifier = Modifier, elevation: Dp = 8.dp, nativeAd: NativeA
         ),
         elevation = CardDefaults.cardElevation(elevation)
     ) {
-        NativeAdView(modifier=Modifier.height(IntrinsicSize.Min)) {
-            Row(modifier = Modifier) {
+        NativeAdView {
+            val contentRatio = nativeAd?.mediaContent?.aspectRatio ?: (16f / 9f)
+            val imageRatio = if (contentRatio > 1.5f) contentRatio else 16f / 9f
+            val nav = LocalNativeAdView.current
+            LaunchedEffect(nativeAd) {
+                if (nativeAd != null)
+                    nav?.setNativeAd(nativeAd)
+            }
+            Row(
+                modifier = Modifier
+                    .height(155.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 // 광고 이미지
-                AdImage(Modifier
-                    .width(160.dp)
-                    .aspectRatio(16f / 9f), image)
+                AdImage(
+                    Modifier
+                        .aspectRatio(imageRatio)
+                )
                 Column(
-                    modifier = Modifier
-                        .padding(6.dp)
-                        .padding(start = 4.dp),
+                    modifier = Modifier.padding(6.dp),
                 ) {
-                    Row {
-                        // 광고 헤드라인
-                        AdHeadLine(Modifier.weight(1f), headline)
-                        Spacer(modifier = Modifier.height(2.dp))
-                        Row(verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                            // 광고주
-                            AdAdvertiser(text = advertiser)
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = 4.dp)
+                            .weight(1f)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            // 광고 헤드라인
+                            AdHeadLine(Modifier.weight(1f), headline) {}
+                            Spacer(modifier = Modifier.height(2.dp))
                             // 광고 마크
                             AdMark()
-                            // 광고 초이스
-                            AdChoice(modifier = Modifier)
+                            Spacer(Modifier.width(6.dp))
                         }
-                    }
-                    Row(modifier=Modifier.weight(1f),
-                        verticalAlignment = Alignment.Top
-                    ){
                         // 광고 바디
-                        AdBody(modifier=Modifier
-                            .weight(0.7f),
-                            text = body)
-                        Spacer(Modifier.width(6.dp))
-                        // 광고 CTA
-                        AdCta(Modifier
-                            .weight(0.45f)
-                            .fillMaxWidth(), nativeAd?.callToAction)
-
+                        AdBody(modifier = Modifier.weight(1f), text = body)
                     }
+                    // 광고주
+                    AdAdvertiser(modifier = Modifier.align(Alignment.End), text = advertiser)
+                    // 광고 CTA
+                    AdCta(modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp), nativeAd?.callToAction)
                 }
             }
         }
@@ -253,94 +302,135 @@ fun RowAd(modifier: Modifier = Modifier, elevation: Dp = 8.dp, nativeAd: NativeA
 
 // 요소
 @Composable
-fun AdChoice(modifier: Modifier = Modifier){
-    NativeAdChoicesView(modifier
-        .clip(RoundedCornerShape(4.dp))
-        .background(
-            brush = Brush.horizontalGradient(
-                colors = listOf(Blue100, Green100)
+fun AdChoice(modifier: Modifier = Modifier) {
+    NativeAdChoicesView(
+        modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(Blue100, Green100)
+                )
             )
-        )
     )
 }
 
 @Composable
-fun AdAdvertiser(modifier: Modifier=Modifier, text:String?){
-    if(text!=null)
-        NativeAdAdvertiserView(modifier =modifier,) {
-            Text(text = text, fontSize = 10.sp,
+fun AdAdvertiser(modifier: Modifier = Modifier, text: String?) {
+    NativeAdAdvertiserView(modifier = modifier) {
+        FontMaxScale(maxScale = AD_MAX_FONT_SCALE) {
+            Text(
+                text = text ?: "", fontSize = 10.sp,
                 color = Gray280, fontFamily = interFontFamily,
-                style = TextStyle(fontSize = 10.sp, lineHeight = 10.sp))
+                style = TextStyle(fontSize = 10.sp, lineHeight = 10.sp)
+            )
+
         }
+    }
 }
 
 @Composable
-fun AdCta(modifier:Modifier, text: String?){
-    Box(modifier=modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter){
-        NativeAdCallToActionView(modifier=modifier
-            .shadow(1.dp, shape = RoundedCornerShape(10.dp))
-            .background(
-                brush = Brush.horizontalGradient(
-                    colors = listOf(Blue50, Green50)
+fun AdCta(modifier: Modifier, text: String?) {
+    NativeAdCallToActionView(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .shadow(1.dp, shape = RoundedCornerShape(8.dp))
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(Blue50, Green50)
+                    )
                 )
-            )
+                .heightIn(min = 48.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Box(
-                modifier= Modifier.clickable {},
-                contentAlignment = Alignment.Center){
-                Text(modifier= Modifier.padding(8.dp),text= text?:"자세히 보기", color = White50, fontSize = 16.sp, fontFamily = interBoldFontFamily)
+            FontMaxScale(maxScale = AD_MAX_FONT_SCALE) {
+                Text(
+                    text = text ?: "자세히 보기",
+                    textAlign = TextAlign.Center,
+                    color = White50,
+                    fontSize = 16.sp,
+                    fontFamily = interBoldFontFamily
+                )
             }
         }
     }
 }
 
 @Composable
-fun AdBody(modifier: Modifier = Modifier, text:String?){
-    if(text!=null)
-        NativeAdBodyView(modifier = modifier){
-            Text(text = text, color = Gray300, fontFamily = hancomSansFontFamily,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
-                style = TextStyle(fontSize = 14.sp, lineHeight = 20.sp))
+fun AdBody(modifier: Modifier = Modifier, maxLine: Int = 3, text: String?) {
+    if (text != null)
+        NativeAdBodyView(modifier = modifier) {
+            Box(contentAlignment = Alignment.CenterStart) {
+                FontMaxScale(maxScale = AD_MAX_FONT_SCALE) {
+                    Text(
+                        modifier = Modifier,
+                        text = text,
+                        color = Gray300,
+                        fontFamily = hancomSansFontFamily,
+                        maxLines = maxLine,
+                        overflow = TextOverflow.Ellipsis,
+                        style = TextStyle(fontSize = 14.sp, lineHeight = 20.sp)
+                    )
+
+                }
+            }
         }
 }
 
 @Composable
-fun AdHeadLine(modifier: Modifier=Modifier, text: String?){
-    if(text!=null)
-      NativeAdHeadlineView(modifier=modifier) {
-          Text(text = text,
-              fontSize = 17.sp,
-              color = Blue500 ,fontFamily = interBoldFontFamily)
-      }
-}
-
-@Composable
-fun AdImage(modifier: Modifier,image: Drawable?){
-    val isPreview = LocalInspectionMode.current
-
-    if(isPreview || image!=null)
-        NativeAdImageView(modifier=modifier) {
-            GlideImage(
-                imageModel = { image },
-                previewPlaceholder = painterResource(R.drawable.lg_app),
-                imageOptions = ImageOptions(contentScale = ContentScale.Crop)
-            )
-        }
-}
-
-@Composable
-fun AdMark(modifier: Modifier = Modifier){
-    Box(modifier = modifier){
-        Box(Modifier
-            .clip(RoundedCornerShape(6.dp))
-            .background(
-                brush = Brush.horizontalGradient(
-                    colors = listOf(Blue100, Green100)
+fun AdHeadLine(
+    modifier: Modifier = Modifier,
+    text: String?,
+    textLayout: (TextLayoutResult) -> Unit
+) {
+    if (text != null)
+        NativeAdHeadlineView(modifier = modifier) {
+            FontMaxScale(maxScale = AD_MAX_FONT_SCALE) {
+                Text(
+                    text = text,
+                    fontSize = 17.sp,
+                    color = Blue500, fontFamily = interBoldFontFamily,
+                    onTextLayout = textLayout
                 )
-            )
-            .padding(horizontal = 4.dp, vertical = 2.dp)) {
-            Text(text = "Ad", color = Color.White, fontFamily = interFontFamily, fontSize = 12.sp, lineHeight = 12.sp)
+            }
+        }
+}
+
+@Composable
+fun AdImage(modifier: Modifier) {
+    val isPreview = LocalInspectionMode.current
+    if (isPreview)
+        GlideImage(
+            modifier = modifier,
+            imageModel = { },
+            previewPlaceholder = painterResource(R.drawable.lg_app),
+            imageOptions = ImageOptions(contentScale = ContentScale.Crop)
+        )
+    else
+        NativeAdMediaView(modifier)
+}
+
+@Composable
+fun AdMark(modifier: Modifier = Modifier) {
+    Box(modifier = modifier) {
+        Box(
+            Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(Blue100, Green100)
+                    )
+                )
+                .padding(horizontal = 2.5.dp, vertical = 1.5.dp)
+        ) {
+            FontMaxScale {
+                Text(
+                    text = "Ad",
+                    color = Color.White,
+                    fontFamily = interFontFamily,
+                    fontSize = 12.sp,
+                    lineHeight = 12.sp
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/FloatingButton.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/FloatingButton.kt
@@ -52,6 +52,7 @@ import com.wheretogo.domain.model.util.Navigation
 import com.wheretogo.presentation.DriveFloatingVisibleMode
 import com.wheretogo.presentation.ExportMap
 import com.wheretogo.presentation.R
+import com.wheretogo.presentation.feature.FontMaxScale
 import com.wheretogo.presentation.feature.callMap
 import com.wheretogo.presentation.state.FloatingButtonState
 import com.wheretogo.presentation.theme.Gray100
@@ -342,11 +343,13 @@ fun InfoText(modifier: Modifier = Modifier, text: String) {
             alignment = Alignment.Center
         )
         Spacer(modifier = Modifier.width(2.dp))
-        Text(
-            text = text,
-            fontSize = 12.sp,
-            color = Color.Gray
-        )
+        FontMaxScale {
+            Text(
+                text = text,
+                fontSize = 12.sp,
+                color = Color.Gray
+            )
+        }
     }
 }
 
@@ -397,12 +400,14 @@ fun SquareScaleButton(
                 modifier = Modifier.fillMaxSize()
             )
         }
-        Text(
-            text = caption,
-            fontFamily = hancomSansFontFamily,
-            fontSize = 10.sp,
-            textAlign = TextAlign.Center
-        )
+        FontMaxScale {
+            Text(
+                text = caption,
+                fontFamily = hancomSansFontFamily,
+                fontSize = 10.sp,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/Placeholder.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/Placeholder.kt
@@ -74,7 +74,7 @@ fun RowAdPlaceholder(modifier: Modifier = Modifier) {
             .background(White50)
             .shimmer()
             .fillMaxWidth()
-            .height(90.dp)
+            .height(120.dp)
             .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/SearchBar.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/SearchBar.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.AdMinSize
 import com.wheretogo.presentation.CLEAR_ADDRESS
 import com.wheretogo.presentation.R
 import com.wheretogo.presentation.feature.intervalTab
@@ -70,7 +71,7 @@ fun SearchBar(
     modifier: Modifier = Modifier,
     state: SearchBarState = SearchBarState(),
     onSearchBarItemClick: (SearchBarItem) -> Unit = {},
-    onSearchBarClick: () -> Unit = {},
+    onSearchBarClick: (Boolean) -> Unit = {},
     onSearchSubmit: (String) -> Unit = {},
     onSearchBarClose: () -> Unit = {}
 ) {
@@ -80,8 +81,9 @@ fun SearchBar(
     var isFocused by remember { mutableStateOf(false) }
     var editText by remember { mutableStateOf("") }
     var alpha by remember { mutableFloatStateOf(0.75f) }
+    var isAdSkip by remember { mutableStateOf(false) }
+    val adSize = adSize()
     val outDp = 12.dp
-
     LaunchedEffect(state.isActive) {
         if (state.isActive) {
             alpha = 1f
@@ -89,6 +91,13 @@ fun SearchBar(
             alpha = 0.75f
             editText = ""
         }
+    }
+
+    LaunchedEffect(adSize) {
+        if(adSize == AdMinSize.Row)
+            isAdSkip = true
+        else
+            isAdSkip = false
     }
 
     fun clearFocus() {
@@ -126,7 +135,7 @@ fun SearchBar(
                         isFocused = it.isFocused
                         when {
                             it.isFocused && editText.isBlank() -> {
-                                onSearchBarClick()
+                                onSearchBarClick(isAdSkip)
                             }
 
                             !it.isFocused && editText.isBlank() -> {
@@ -195,10 +204,10 @@ fun SearchBar(
             ) {
                 AdaptiveAd(
                     modifier = Modifier.padding(bottom = outDp, start = outDp, end = outDp),
+                    isCompact = true,
                     nativeAd = state.adItemGroup.firstOrNull()?.nativeAd
                 )
             }
-
         }
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/ad/NativeAdView.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/ad/NativeAdView.kt
@@ -58,7 +58,7 @@ fun NativeAdView(modifier: Modifier = Modifier, content: @Composable () -> Unit)
                 layoutParams =
                     ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
                     )
                 addView(
                     ComposeView(context).apply {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/effect/AdLaunch.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/effect/AdLaunch.kt
@@ -1,0 +1,36 @@
+package com.wheretogo.presentation.composable.effect
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalDensity
+import com.google.android.gms.ads.nativead.NativeAd
+import com.wheretogo.presentation.composable.content.ad.LocalNativeAdView
+
+
+@Composable
+fun CardAdEffect(nativeAd: NativeAd?, isCompact: Boolean, tiltLines:Int, onMaxLineUpdate: (Int)-> Unit){
+    val density = LocalDensity.current
+    val fontScale = density.fontScale
+    val nav = LocalNativeAdView.current
+    if (isCompact) {
+        LaunchedEffect(tiltLines, fontScale) {
+            if (tiltLines != -1) {
+                val maxLine= when {
+                    fontScale >= 1.1f && tiltLines >= 2 -> 0
+                    tiltLines > 1 -> 1
+                    else -> {
+                        2
+                    }
+                }
+                onMaxLineUpdate(maxLine)
+                if (nativeAd != null)
+                    nav?.setNativeAd(nativeAd)
+            }
+        }
+    } else {
+        LaunchedEffect(nativeAd) {
+            if (nativeAd != null)
+                nav?.setNativeAd(nativeAd)
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/ComposableControl.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/ComposableControl.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -28,6 +29,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.wheretogo.presentation.theme.Gray6080
@@ -114,5 +116,20 @@ fun Modifier.intervalTab(
                 }
             },
         )
+    }
+}
+
+@Composable
+fun FontMaxScale(
+    maxScale: Float = 1.0f,
+    content: @Composable () -> Unit
+) {
+    val density = LocalDensity.current
+    val capped = Density(
+        density = density.density,
+        fontScale = minOf(density.fontScale, maxScale)
+    )
+    CompositionLocalProvider(LocalDensity provides capped) {
+        content()
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/intent/DriveScreenIntent.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/intent/DriveScreenIntent.kt
@@ -18,7 +18,7 @@ sealed class DriveScreenIntent {
 
     //서치바
     data class AddressItemClick(val searchBarItem: SearchBarItem) : DriveScreenIntent()
-    data object SearchBarClick : DriveScreenIntent()
+    data class SearchBarClick(val isSkipAd: Boolean) : DriveScreenIntent()
     data object SearchBarClose : DriveScreenIntent()
     data class SearchSubmit(val submit:String) : DriveScreenIntent()
 

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/DriveViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/DriveViewModel.kt
@@ -76,7 +76,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.round
 
@@ -118,7 +117,7 @@ class DriveViewModel @Inject constructor(
             when (intent) {
                 //서치바
                 is DriveScreenIntent.AddressItemClick -> searchBarItemClick(intent.searchBarItem)
-                is DriveScreenIntent.SearchBarClick -> searchBarClick()
+                is DriveScreenIntent.SearchBarClick -> searchBarClick(intent.isSkipAd)
                 is DriveScreenIntent.SearchBarClose -> searchBarClose()
                 is DriveScreenIntent.SearchSubmit -> searchSubmit(intent.submit) // ✅
 
@@ -180,7 +179,6 @@ class DriveViewModel @Inject constructor(
         }
     }
 
-
     //서치바
     private fun searchBarItemClick(item: SearchBarItem) {
         if (item.label == CLEAR_ADDRESS || item.latlng == null) {
@@ -231,7 +229,12 @@ class DriveViewModel @Inject constructor(
         }
     }
 
-    private fun searchBarClick() {
+    private fun searchBarClick(isSkipAd: Boolean) {
+        if(_driveScreenState.value.stateMode == DriveVisibleMode.SearchBarExpand) {
+            searchBarClose()
+            return
+        }
+
         mapOverlayService.removeCheckPoint(listOf(SEARCH_MARKER))
         _driveScreenState.update {
             it.run {
@@ -246,11 +249,12 @@ class DriveViewModel @Inject constructor(
 
         }
 
-        if (_driveScreenState.value.searchBarState.adItemGroup.isEmpty()) {
+
+        if (!isSkipAd && _driveScreenState.value.searchBarState.adItemGroup.isEmpty()) {
             loadAd()
-        } else {
-            searchBarClose()
         }
+
+
     }
 
     private fun searchBarClose() {


### PR DESCRIPTION
### 1. 폰트 스케일 대응
- 광고안 폰트의 확대를 1.2 배로 제한
- 확대시 부족한 영역을 비 필수요소 영역을 사용해 필수요소가 가려지지 않게함

### 2. ui 간섭 대응
- 광고 영역이 충분히 확보되지않는 (ex: 가로화면 서치바)화면 에서 광고를 숨김

## ✅ 테스트 항목
- [x]  폰트를 최대한 확대후 광고 필수요소가 제대로 표시되는지 확인
- [x] 광고 표시영역중 가려지는 부분이 없는지 확인