### PR TITLE
히스토리 모델 id 그룹화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("com.google.devtools.ksp") version "2.0.0-1.0.24" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.2" apply false
+    kotlin("plugin.serialization") version "1.8.0" apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/buildSrc/src/main/kotlin/wheretogo/Deps.kt
+++ b/buildSrc/src/main/kotlin/wheretogo/Deps.kt
@@ -48,8 +48,8 @@ object Versions {
 
 object Kotlin {
     const val KOTLIN_BOM = "org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}"
-    const val KOTLIN_COROUTINES_PLAY_SERVICES = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0"
-
+    const val KOTLINX_COROUTINES_PLAY_SERVICES = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0"
+    const val KOTLINX_SERIALIZATION_CBOR = "org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.8.0"
 }
 
 object AndroidX {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("com.google.dagger.hilt.android")
+    kotlin("plugin.serialization")
     id("com.google.devtools.ksp")
 }
 
@@ -75,6 +76,9 @@ dependencies {
 
     // Bom
     implementation(platform(Kotlin.KOTLIN_BOM))
+
+    // Kotlin
+    implementation(Kotlin.KOTLINX_SERIALIZATION_CBOR)
 
     // Androidx
     api(AndroidX.ROOM_KTX)

--- a/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
@@ -1,22 +1,22 @@
 package com.wheretogo.data.datasource
 
+import com.wheretogo.data.model.history.LocalHistory
 import com.wheretogo.data.model.history.LocalHistoryGroupWrapper
 import com.wheretogo.data.model.user.LocalProfile
 import com.wheretogo.domain.HistoryType
-import com.wheretogo.domain.model.user.History
 import kotlinx.coroutines.flow.Flow
 
 interface UserLocalDatasource {
 
-    suspend fun addHistory(type: HistoryType, historyId: String, addedAt: Long): Result<Unit>
+    suspend fun addHistory(type: HistoryType, groupId: String, historyId: String, addedAt: Long): Result<Unit>
 
-    suspend fun removeHistory(type: HistoryType, historyId: String): Result<Unit>
+    suspend fun removeHistory(type: HistoryType, groupId: String, historyId: String): Result<Unit>
 
     suspend fun getHistory(type: HistoryType): LocalHistoryGroupWrapper
 
     suspend fun setProfile(profile: LocalProfile): Result<Unit>
 
-    suspend fun setHistory(history: History): Result<Unit>
+    suspend fun iniHistory(history: LocalHistory): Result<Unit>
 
     suspend fun clearUser(): Result<Unit>
 

--- a/data/src/main/java/com/wheretogo/data/datasource/UserRemoteDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/UserRemoteDatasource.kt
@@ -14,8 +14,8 @@ interface UserRemoteDatasource {
     suspend fun deleteProfile(uid: String): Result<Unit>
     suspend fun deleteUser(userId: String): Result<String>
 
-    suspend fun addHistory(uid: String, historyId: String, type: HistoryType): Result<Long>
-    suspend fun removeHistory(uid: String, historyId: String, type: HistoryType): Result<Unit>
     suspend fun getHistoryGroup(uid: String): Result<List<RemoteHistoryGroupWrapper>>
     suspend fun setHistoryGroup(uid: String, wrapper: RemoteHistoryGroupWrapper): Result<Unit>
+    suspend fun addHistory(type: HistoryType, uid: String, groupId: String, historyId: String): Result<Long>
+    suspend fun removeHistory(type: HistoryType, uid: String, groupId: String, historyId: String): Result<Unit>
 }

--- a/data/src/main/java/com/wheretogo/data/model/history/LocalHistory.kt
+++ b/data/src/main/java/com/wheretogo/data/model/history/LocalHistory.kt
@@ -1,0 +1,10 @@
+package com.wheretogo.data.model.history
+
+data class LocalHistory(
+    val course: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+    val checkpoint: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+    val comment: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+    val like: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+    val bookmark: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+    val report: LocalHistoryGroupWrapper = LocalHistoryGroupWrapper(),
+)

--- a/data/src/main/java/com/wheretogo/data/model/history/LocalHistoryGroupWrapper.kt
+++ b/data/src/main/java/com/wheretogo/data/model/history/LocalHistoryGroupWrapper.kt
@@ -4,6 +4,6 @@ import com.wheretogo.domain.HistoryType
 
 data class LocalHistoryGroupWrapper(
     val type: HistoryType = HistoryType.LIKE,
-    val historyIdGroup: HashSet<String> = hashSetOf(),
+    val historyIdGroup: LocalHistoryIdGroup = LocalHistoryIdGroup(),
     val lastAddedAt: Long = 0L
 )

--- a/data/src/main/java/com/wheretogo/data/model/history/LocalHistoryIdGroup.kt
+++ b/data/src/main/java/com/wheretogo/data/model/history/LocalHistoryIdGroup.kt
@@ -1,0 +1,10 @@
+package com.wheretogo.data.model.history
+
+import android.annotation.SuppressLint
+import kotlinx.serialization.Serializable
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class LocalHistoryIdGroup(
+    val groupById: Map<String, HashSet<String>> = emptyMap(),
+)

--- a/data/src/main/java/com/wheretogo/data/model/history/RemoteHistoryGroupWrapper.kt
+++ b/data/src/main/java/com/wheretogo/data/model/history/RemoteHistoryGroupWrapper.kt
@@ -4,6 +4,6 @@ import com.wheretogo.domain.HistoryType
 
 data class RemoteHistoryGroupWrapper(
     val type: HistoryType = HistoryType.LIKE,
-    val historyIdGroup: List<String> = emptyList(),
+    val historyIdGroup: Map<String, List<String>> = emptyMap(),
     val lastAddedAt: Long = 0L
 )

--- a/domain/src/main/java/com/wheretogo/domain/DomainMapper.kt
+++ b/domain/src/main/java/com/wheretogo/domain/DomainMapper.kt
@@ -11,6 +11,7 @@ import com.wheretogo.domain.model.comment.CommentAddRequest
 import com.wheretogo.domain.model.comment.CommentContent
 import com.wheretogo.domain.model.course.CourseAddRequest
 import com.wheretogo.domain.model.course.CourseContent
+import com.wheretogo.domain.model.history.HistoryIdGroup
 import com.wheretogo.domain.model.user.AuthProfile
 import com.wheretogo.domain.model.user.History
 import com.wheretogo.domain.model.user.Profile
@@ -52,31 +53,31 @@ fun CommentContent.toCommentAddRequest(
     )
 }
 
-fun History.map(type: HistoryType, data: HashSet<String>): History {
+fun History.map(type: HistoryType, data: Map<String, HashSet<String>>): History {
     return when (type) {
         HistoryType.COURSE -> {
-            copy(course=course.copy(type,data))
+            copy(course = course.copy(type, HistoryIdGroup(data)))
         }
 
         HistoryType.CHECKPOINT -> {
-            copy(checkpoint = checkpoint.copy(type,data))
+            copy(checkpoint = checkpoint.copy(type, HistoryIdGroup(data)))
         }
 
         HistoryType.COMMENT -> {
-            copy(comment = comment.copy(type,data))
+            copy(comment = comment.copy(type, HistoryIdGroup(data)))
         }
 
         HistoryType.REPORT -> {
-            copy(checkpoint = checkpoint.copy(type,data))
+            copy(checkpoint = checkpoint.copy(type, HistoryIdGroup(data)))
         }
 
         HistoryType.LIKE -> {
-            copy(like = like.copy(type,data))
+            copy(like = like.copy(type, HistoryIdGroup(data)))
         }
     }
 }
 
-fun History.get(type: HistoryType): HashSet<String> {
+fun History.get(type: HistoryType): HistoryIdGroup {
     return when (type) {
         HistoryType.COURSE -> {
             course.historyIdGroup

--- a/domain/src/main/java/com/wheretogo/domain/model/history/HistoryGroupWrapper.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/history/HistoryGroupWrapper.kt
@@ -4,6 +4,6 @@ import com.wheretogo.domain.HistoryType
 
 data class HistoryGroupWrapper(
     val type: HistoryType = HistoryType.LIKE,
-    val historyIdGroup: HashSet<String> = hashSetOf(),
+    val historyIdGroup: HistoryIdGroup = HistoryIdGroup(),
     val lastAddedAt: Long = 0L
 )

--- a/domain/src/main/java/com/wheretogo/domain/model/history/HistoryIdGroup.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/history/HistoryIdGroup.kt
@@ -1,0 +1,5 @@
+package com.wheretogo.domain.model.history
+
+data class HistoryIdGroup(
+    val groupById: Map<String, HashSet<String>> = emptyMap(),
+)

--- a/domain/src/main/java/com/wheretogo/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/UserRepository.kt
@@ -21,22 +21,26 @@ interface UserRepository {
 
     suspend fun addHistory(
         type: HistoryType,
+        groupId: String,
         historyId: String
     ): Result<Unit>
 
     suspend fun addHistoryToLocal(
         type: HistoryType,
+        groupId: String,
         historyId: String,
         addedAt: Long = 0
     ): Result<Unit>
 
     suspend fun removeHistory(
         type: HistoryType,
+        groupId: String,
         historyId: String
     ): Result<Unit>
 
     suspend fun removeHistoryToLocal(
         type: HistoryType,
+        groupId: String,
         historyId: String
     ): Result<Unit>
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
     implementation(platform(Compose.COMPOSE_BOM))
 
     // KOTLIN
-    implementation(Kotlin.KOTLIN_COROUTINES_PLAY_SERVICES)
+    implementation(Kotlin.KOTLINX_COROUTINES_PLAY_SERVICES)
 
     // Compose
     implementation(Compose.COMPOSE_UI)

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationMapper.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationMapper.kt
@@ -36,11 +36,6 @@ fun List<LatLng>.toNaver(): List<NaverLatLng> {
     return this.map { NaverLatLng(it.latitude, it.longitude) }
 }
 
-
-fun List<NaverLatLng>.toDomain(): List<LatLng> {
-    return map { it.toDomainLatLng() }
-}
-
 fun NaverLatLng.toDomainLatLng(): LatLng {
     return LatLng(latitude, longitude)
 }
@@ -50,7 +45,12 @@ fun LatLng.toNaver(): NaverLatLng {
 }
 
 fun SimpleAddress.toSearchBarItem(): SearchBarItem {
-    return SearchBarItem(label = title, address = address, latlng = latlng, isCourse = type == SearchType.COURSE)
+    return SearchBarItem(
+        label = title,
+        address = address,
+        latlng = latlng,
+        isCourse = type == SearchType.COURSE
+    )
 }
 
 fun RouteAttr.toStrRes(): Int {
@@ -58,7 +58,6 @@ fun RouteAttr.toStrRes(): Int {
         RouteAttr.TYPE -> R.string.category
         RouteAttr.LEVEL -> R.string.level
         RouteAttr.RELATION -> R.string.recommend
-        else -> R.string.unknown
     }
 }
 
@@ -101,7 +100,7 @@ fun CheckPointAddState.toCheckPointContent(courseId: String): CheckPointContent 
     )
 }
 
-fun CommentAddState.toCommentContent(groupId: String, editText:String): CommentContent {
+fun CommentAddState.toCommentContent(groupId: String, editText: String): CommentContent {
     return CommentContent(
         groupId = groupId,
         emoji = this.largeEmoji.ifEmpty { emogiGroup.firstOrNull() ?: "" },
@@ -118,14 +117,10 @@ fun Comment.toCommentItemState(): CommentState.CommentItemState {
     )
 }
 
-fun CommentState.CommentItemState.toComment(): Comment {
-    return data
-}
-
 fun parseLogoImgRes(company: String): Int {
     val auth = try {
         AuthCompany.valueOf(company)
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         AuthCompany.GOOGLE
     }
 


### PR DESCRIPTION
### 1. 히스토리 저장시 컨텐츠의 그룹 id별로 묶어서 저장

## ✅ 테스트 항목
- [x]  컨텐츠(코스, 체크포인트, 댓글) 추가시 히스토리 그룹별로 저장 확인
- [x]  컨텐츠 삭제시 히스토리 삭제 확인
- [x]  히스토리 기반 나의 컨텐츠 여부 확인