### PR TITLE
미디어 피커 화면 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,9 +4,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <queries>
         <package android:name="com.skt.skaf.l001mtm091"/>
         <package android:name="com.skt.tmap.ku"/>

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/BottomSheetTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/BottomSheetTest.kt
@@ -83,7 +83,7 @@ class BottomSheetTest {
             handler = driveHandler,
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = mockk(),
-            getImageForPopupUseCase = mockk(),
+            getImageUseCase = mockk(),
             addCheckpointToCourseUseCase = addCheckpointToCourseUseCase,
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = removeCourseUseCase,
@@ -350,7 +350,7 @@ class BottomSheetTest {
             // Assert: 로딩 표시
             state.awaitItem().run {
                 bottomSheetState.checkPointAddState.let {
-                    assertThat(it.isLoading).isEqualTo(true)
+                    assertThat(it.isButtonLoading).isEqualTo(true)
                 }
             }
             // Assert: 체크포인트 마커 추가

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/CommonTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/CommonTest.kt
@@ -6,8 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.wheretogo.data.repositoryimpl.MapContentRepositoryImpl
 import com.wheretogo.domain.DriveTutorialStep
 import com.wheretogo.domain.model.app.Settings
-import com.wheretogo.domain.model.course.Course
-import com.wheretogo.domain.repository.MapContentRepository
 import com.wheretogo.domain.usecase.app.DriveTutorialUseCase
 import com.wheretogo.domain.usecase.app.ObserveSettingsUseCase
 import com.wheretogo.presentation.AppEvent
@@ -24,7 +22,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -59,7 +56,7 @@ class CommonTest {
             handler = mockk(),
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = mockk(),
-            getImageForPopupUseCase = mockk(),
+            getImageUseCase = mockk(),
             addCheckpointToCourseUseCase = mockk(),
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = mockk(),

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/DriveListTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/DriveListTest.kt
@@ -53,7 +53,7 @@ class DriveListTest {
             handler = mockk(),
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = mockk(),
-            getImageForPopupUseCase = mockk(),
+            getImageUseCase = mockk(),
             addCheckpointToCourseUseCase = mockk(),
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = mockk(),

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/FloatingButtonTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/FloatingButtonTest.kt
@@ -71,7 +71,7 @@ class FloatingButtonTest {
             handler = mockk(),
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = getCommentForCheckPointUseCase,
-            getImageForPopupUseCase = mockk(),
+            getImageUseCase = mockk(),
             addCheckpointToCourseUseCase = mockk(),
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = mockk(),

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/PopUpTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/PopUpTest.kt
@@ -15,7 +15,7 @@ import com.wheretogo.domain.usecase.comment.RemoveCommentToCheckPointUseCase
 import com.wheretogo.domain.repository.DefaultMapId
 import com.wheretogo.domain.usecase.app.DriveTutorialUseCase
 import com.wheretogo.domain.usecase.report.ReportContentUseCase
-import com.wheretogo.domain.usecase.util.GetImageForPopupUseCase
+import com.wheretogo.domain.usecase.util.GetImageUseCase
 import com.wheretogo.domain.usecase.util.UpdateLikeUseCase
 import com.wheretogo.presentation.CommentType
 import com.wheretogo.presentation.DriveFloatingVisibleMode
@@ -45,7 +45,7 @@ class PopUpTest {
 
     private val initState = DriveScreenState(isObserveSetting = false)
     private val observeSettingsUseCase = mockk<ObserveSettingsUseCase>()
-    private val getImageForPopupUseCase = mockk<GetImageForPopupUseCase>()
+    private val getImageUseCase = mockk<GetImageUseCase>()
     private val getCommentForCheckPointUseCase = mockk<GetCommentForCheckPointUseCase>()
     private val removeCommentToCheckPointUseCase = mockk<RemoveCommentToCheckPointUseCase>()
     private val reportContentUseCase = mockk<ReportContentUseCase>()
@@ -67,7 +67,7 @@ class PopUpTest {
             handler = mockk(),
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = getCommentForCheckPointUseCase,
-            getImageForPopupUseCase = getImageForPopupUseCase,
+            getImageUseCase = getImageUseCase,
             addCheckpointToCourseUseCase = mockk(),
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = mockk(),
@@ -130,7 +130,7 @@ class PopUpTest {
         val viewModel =
             createViewModel(StandardTestDispatcher(testScheduler), showPopupImageAndCommentState)
 
-        coEvery { getImageForPopupUseCase(slideItem1.imageId!!) } returns item1Url
+        coEvery { getImageUseCase(slideItem1.imageId!!) } returns item1Url
         coEvery { getCommentForCheckPointUseCase(slideItem1.contentId!!) } returns Result.success(emptyList())
 
         assertFlows(viewModel.driveScreenState, viewModel.driveEvent) {

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/SearchBarTest.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/drive/SearchBarTest.kt
@@ -65,7 +65,7 @@ class SearchBarTest {
             handler = mockk(),
             observeSettingsUseCase = observeSettingsUseCase,
             getCommentForCheckPointUseCase = mockk(),
-            getImageForPopupUseCase = mockk(),
+            getImageUseCase = mockk(),
             addCheckpointToCourseUseCase = mockk(),
             addCommentToCheckPointUseCase = mockk(),
             removeCourseUseCase = mockk(),

--- a/app/src/test/java/com/dhkim139/wheretogo/viewmodel/guide/ViewModelTestByGuide.kt
+++ b/app/src/test/java/com/dhkim139/wheretogo/viewmodel/guide/ViewModelTestByGuide.kt
@@ -19,7 +19,7 @@ import com.wheretogo.domain.usecase.course.FilterListCourseUseCase
 import com.wheretogo.domain.usecase.course.GetNearByCourseUseCase
 import com.wheretogo.domain.usecase.course.RemoveCourseUseCase
 import com.wheretogo.domain.usecase.user.UserSignOutUseCase
-import com.wheretogo.domain.usecase.util.GetImageForPopupUseCase
+import com.wheretogo.domain.usecase.util.GetImageUseCase
 import com.wheretogo.domain.usecase.util.SearchKeywordUseCase
 import com.wheretogo.domain.usecase.util.UpdateLikeUseCase
 import com.wheretogo.presentation.HomeBodyBtn
@@ -121,7 +121,7 @@ class ViewModelTestByGuide {
     private val getNearByCourseUseCase = mockk<GetNearByCourseUseCase>()
     private val getCommentForCheckPointUseCase = mockk<GetCommentForCheckPointUseCase>()
     private val getCheckPointForMarkerUseCase = mockk<GetCheckpointForMarkerUseCase>()
-    private val getImageForPopupUseCase = mockk<GetImageForPopupUseCase>()
+    private val getImageUseCase = mockk<GetImageUseCase>()
     private val addCheckpointToCourseUseCase = mockk<AddCheckpointToCourseUseCase>()
     private val addCommentToCheckPointUseCase = mockk<AddCommentToCheckPointUseCase>()
     private val updateLikeUseCase = mockk<UpdateLikeUseCase>()

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -1,6 +1,7 @@
 package com.wheretogo.data.datasource
 
 import com.wheretogo.domain.ImageSize
+import com.wheretogo.domain.usecase.util.ExifData
 import java.io.File
 
 
@@ -19,4 +20,6 @@ interface ImageLocalDatasource {
         sizeGroup: List<ImageSize>,
         compressionQuality: Int = 80
     ): Result<List<Pair<ImageSize, ByteArray>>>
+
+    suspend fun getExif(imageUriString:String): Result<ExifData>
 }

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -1,6 +1,7 @@
 package com.wheretogo.data.datasource
 
 import com.wheretogo.domain.ImageSize
+import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.usecase.util.ExifData
 import java.io.File
 
@@ -21,5 +22,7 @@ interface ImageLocalDatasource {
         compressionQuality: Int = 80
     ): Result<List<Pair<ImageSize, ByteArray>>>
 
-    suspend fun getExif(imageUriString:String): Result<ExifData>
+    suspend fun getExif(imageUriString: String): Result<ExifData>
+
+    suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -1,10 +1,17 @@
 package com.wheretogo.data.datasourceimpl
 
+import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.Context
+import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
 import androidx.core.graphics.createBitmap
 import androidx.core.net.toUri
+import androidx.core.os.bundleOf
 import androidx.exifinterface.media.ExifInterface
 import com.wheretogo.data.ImageFormat
 import com.wheretogo.data.datasource.ImageLocalDatasource
@@ -14,6 +21,7 @@ import com.wheretogo.domain.feature.fit
 import com.wheretogo.domain.feature.rotate
 import com.wheretogo.domain.feature.scale
 import com.wheretogo.domain.feature.scaleCrop
+import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.usecase.util.ExifData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
@@ -31,6 +39,8 @@ class ImageLocalDatasourceImpl @Inject constructor(
     private val imageConfig: ImageConfig
 ) : ImageLocalDatasource {
     private val ext = imageConfig.format.ext
+    private val mediaUri: Uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+
     override suspend fun getImage(imageId: String, size: ImageSize): File {
         val localFile =
             File(
@@ -177,6 +187,41 @@ class ImageLocalDatasourceImpl @Inject constructor(
                     focalLength = exif.getAttribute(ExifInterface.TAG_FOCAL_LENGTH)
                 )
             }!!
+        }
+    }
+
+    override suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>> {
+        return runCatching {
+            queryImages(offset, limit)?.use { cursor ->
+                cursor.toMediaImages()
+            } ?: emptyList()
+        }
+    }
+
+    private fun queryImages(offset: Int, limit: Int): Cursor? {
+        val projection = arrayOf(MediaStore.Images.Media._ID)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val args = bundleOf(
+                ContentResolver.QUERY_ARG_SORT_COLUMNS to arrayOf(MediaStore.Images.Media.DATE_ADDED),
+                ContentResolver.QUERY_ARG_SORT_DIRECTION to ContentResolver.QUERY_SORT_DIRECTION_DESCENDING,
+                ContentResolver.QUERY_ARG_LIMIT to limit,
+                ContentResolver.QUERY_ARG_OFFSET to offset,
+            )
+            context.contentResolver.query(mediaUri, projection, args, null)
+        } else {
+            val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC LIMIT $limit OFFSET $offset"
+            context.contentResolver.query(mediaUri, projection, null, null, sortOrder)
+        }
+    }
+
+    private fun Cursor.toMediaImages(): List<MediaImage> {
+        val idCol = getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+        return buildList(count) {
+            while (moveToNext()) {
+                val id = getLong(idCol)
+                val uri = ContentUris.withAppendedId(mediaUri, id).toString()
+                add(MediaImage(id, uri))
+            }
         }
     }
 

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -14,12 +14,15 @@ import com.wheretogo.domain.feature.fit
 import com.wheretogo.domain.feature.rotate
 import com.wheretogo.domain.feature.scale
 import com.wheretogo.domain.feature.scaleCrop
+import com.wheretogo.domain.usecase.util.ExifData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
 import javax.inject.Inject
 
 class ImageLocalDatasourceImpl @Inject constructor(
@@ -134,6 +137,55 @@ class ImageLocalDatasourceImpl @Inject constructor(
                     }
                 }.awaitAll()
             }
+        }
+    }
+
+    override suspend fun getExif(imageUriString: String): Result<ExifData> {
+        return runCatching {
+            context.contentResolver.openInputStream(imageUriString.toUri())?.use { stream ->
+                val exif = ExifInterface(stream)
+
+                val latlng = exif.latLong
+                val hasLatLong = latlng != null
+                val altitude = if (exif.hasAttribute(ExifInterface.TAG_GPS_ALTITUDE)) {
+                    exif.getAltitude(0.0)
+                } else null
+
+                val dateTimeStr = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)
+                    ?: exif.getAttribute(ExifInterface.TAG_DATETIME)
+                val timestamp = dateTimeStr?.let { parseExifDateTime(it) }
+
+                ExifData(
+                    latitude = if (hasLatLong) latlng[0] else null,
+                    longitude = if (hasLatLong) latlng[1] else null,
+                    altitude = altitude,
+                    dateTimeOriginal = dateTimeStr,
+                    timestampMillis = timestamp,
+                    make = exif.getAttribute(ExifInterface.TAG_MAKE),
+                    model = exif.getAttribute(ExifInterface.TAG_MODEL),
+                    orientation = exif.getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_NORMAL
+                    ),
+                    imageWidth = exif.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0)
+                        .takeIf { it > 0 },
+                    imageHeight = exif.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0)
+                        .takeIf { it > 0 },
+                    fNumber = exif.getAttribute(ExifInterface.TAG_F_NUMBER),
+                    exposureTime = exif.getAttribute(ExifInterface.TAG_EXPOSURE_TIME),
+                    iso = exif.getAttribute(ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY),
+                    focalLength = exif.getAttribute(ExifInterface.TAG_FOCAL_LENGTH)
+                )
+            }!!
+        }
+    }
+
+    private fun parseExifDateTime(dateTime: String): Long? {
+        return try {
+            val format = SimpleDateFormat("yyyy:MM:dd HH:mm:ss", Locale.KOREA)
+            format.parse(dateTime)?.time
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.feature.flatMap
 import com.wheretogo.domain.model.util.ImageUris
 import com.wheretogo.domain.repository.ImageRepository
+import com.wheretogo.domain.usecase.util.ExifData
 import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -69,6 +70,10 @@ class ImageRepositoryImpl @Inject constructor(
                 }
             }.awaitAll().flatMap()
         }.mapCatching { Unit }.mapDataError().mapDomainError()
+    }
+
+    override suspend fun getExif(imageUriString: String): Result<ExifData> {
+        return imageLocalDatasource.getExif(imageUriString)
     }
 
     private suspend fun uploadAndSaveImage(imageId: String, size: ImageSize, bytes: ByteArray): Pair<ImageSize, String> {

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.wheretogo.data.feature.mapSuccess
 import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.feature.flatMap
 import com.wheretogo.domain.model.util.ImageUris
+import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.repository.ImageRepository
 import com.wheretogo.domain.usecase.util.ExifData
 import de.huxhorn.sulky.ulid.ULID
@@ -74,6 +75,13 @@ class ImageRepositoryImpl @Inject constructor(
 
     override suspend fun getExif(imageUriString: String): Result<ExifData> {
         return imageLocalDatasource.getExif(imageUriString)
+    }
+
+    override suspend fun getMediaImages(
+        offset: Int,
+        limit: Int
+    ): Result<List<MediaImage>> {
+        return imageLocalDatasource.getMediaImages(offset, limit)
     }
 
     private suspend fun uploadAndSaveImage(imageId: String, size: ImageSize, bytes: ByteArray): Pair<ImageSize, String> {

--- a/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
@@ -24,7 +24,7 @@ import com.wheretogo.domain.usecase.util.ClearCacheUseCase
 import com.wheretogo.domain.usecase.util.ClearExpireCacheUseCase
 import com.wheretogo.domain.usecase.util.CourseAddValidUseCase
 import com.wheretogo.domain.usecase.util.CreateRouteUseCase
-import com.wheretogo.domain.usecase.util.GetImageForPopupUseCase
+import com.wheretogo.domain.usecase.util.GetImageUseCase
 import com.wheretogo.domain.usecase.util.GetLatLngFromAddressUseCase
 import com.wheretogo.domain.usecase.util.SearchKeywordUseCase
 import com.wheretogo.domain.usecase.util.UpdateLikeUseCase
@@ -52,7 +52,7 @@ import com.wheretogo.domain.usecaseimpl.util.ClearCacheUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.ClearExpireCacheUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.CourseAddValidUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.CreateRouteUseCaseImpl
-import com.wheretogo.domain.usecaseimpl.util.GetImageForPopupUseCaseImpl
+import com.wheretogo.domain.usecaseimpl.util.GetImageUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.GetLatLngFromAddressUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.SearchKeywordUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.UpdateLikeUseCaseImpl
@@ -114,7 +114,7 @@ abstract class UseCaseModule {
     abstract fun bindReportContentUseCase(useCaseImpl: ReportContentUseCaseImpl): ReportContentUseCase
 
     @Binds
-    abstract fun bindGetImageForPopupUseCase(useCaseImpl: GetImageForPopupUseCaseImpl): GetImageForPopupUseCase
+    abstract fun bindGetImageUseCase(useCaseImpl: GetImageUseCaseImpl): GetImageUseCase
 
     @Binds
     abstract fun bindCreateRouteUseCase(useCaseImpl: CreateRouteUseCaseImpl): CreateRouteUseCase

--- a/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
@@ -25,6 +25,7 @@ import com.wheretogo.domain.usecase.util.ClearExpireCacheUseCase
 import com.wheretogo.domain.usecase.util.CourseAddValidUseCase
 import com.wheretogo.domain.usecase.util.CreateRouteUseCase
 import com.wheretogo.domain.usecase.util.GetImageUseCase
+import com.wheretogo.domain.usecase.util.GetImagesPageUseCase
 import com.wheretogo.domain.usecase.util.GetLatLngFromAddressUseCase
 import com.wheretogo.domain.usecase.util.SearchKeywordUseCase
 import com.wheretogo.domain.usecase.util.UpdateLikeUseCase
@@ -53,6 +54,7 @@ import com.wheretogo.domain.usecaseimpl.util.ClearExpireCacheUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.CourseAddValidUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.CreateRouteUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.GetImageUseCaseImpl
+import com.wheretogo.domain.usecaseimpl.util.GetImagesPageUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.GetLatLngFromAddressUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.SearchKeywordUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.util.UpdateLikeUseCaseImpl
@@ -151,6 +153,9 @@ abstract class UseCaseModule {
 
     @Binds
     abstract fun bindClearExpireCacheUseCase(useCaseImpl: ClearExpireCacheUseCaseImpl): ClearExpireCacheUseCase
+
+    @Binds
+    abstract fun bindGetImagesPageUseCase(useCaseImpl: GetImagesPageUseCaseImpl): GetImagesPageUseCase
 
 }
 

--- a/domain/src/main/java/com/wheretogo/domain/model/util/MediaImage.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/util/MediaImage.kt
@@ -1,0 +1,6 @@
+package com.wheretogo.domain.model.util
+
+data class MediaImage(
+    val id: Long,
+    val uriString: String,
+)

--- a/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
@@ -2,9 +2,11 @@ package com.wheretogo.domain.repository
 
 import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.model.util.ImageUris
+import com.wheretogo.domain.usecase.util.ExifData
 
 interface ImageRepository {
     suspend fun getImage(imageId: String, size: ImageSize): Result<String>
     suspend fun setImage(imgUriString: String): Result<ImageUris>
     suspend fun removeImage(imageId: String): Result<Unit>
+    suspend fun getExif(imageUriString: String): Result<ExifData>
 }

--- a/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
@@ -2,6 +2,7 @@ package com.wheretogo.domain.repository
 
 import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.model.util.ImageUris
+import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.usecase.util.ExifData
 
 interface ImageRepository {
@@ -9,4 +10,5 @@ interface ImageRepository {
     suspend fun setImage(imgUriString: String): Result<ImageUris>
     suspend fun removeImage(imageId: String): Result<Unit>
     suspend fun getExif(imageUriString: String): Result<ExifData>
+    suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/util/GetImageUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/util/GetImageUseCase.kt
@@ -1,5 +1,5 @@
 package com.wheretogo.domain.usecase.util
 
-interface GetImageForPopupUseCase {
+interface GetImageUseCase {
     suspend operator fun invoke(imageId: String): String?
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/util/GetImageUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/util/GetImageUseCase.kt
@@ -1,5 +1,33 @@
 package com.wheretogo.domain.usecase.util
 
+import com.wheretogo.domain.model.address.LatLng
+
+
+data class ExifData(
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val altitude: Double? = null,          // 고도(m)
+    val dateTimeOriginal: String? = null,  // 촬영 시각 (원본 문자열)
+    val timestampMillis: Long? = null,     // 촬영 시각 (epoch millis)
+    val make: String? = null,              // 제조사
+    val model: String? = null,             // 모델명
+    val orientation: Int? = null,          // 회전 정보
+    val imageWidth: Int? = null,
+    val imageHeight: Int? = null,
+    val fNumber: String? = null,           // 조리개
+    val exposureTime: String? = null,      // 셔터스피드
+    val iso: String? = null,
+    val focalLength: String? = null
+) {
+    val getLatLng: LatLng?
+        get() = if (latitude != null && longitude != null) LatLng(latitude, longitude) else null
+}
+
+data class NearLatLng(
+    val percent: Float,
+    val latlng: LatLng
+)
 interface GetImageUseCase {
     suspend operator fun invoke(imageId: String): String?
+    suspend fun getNearLatLng(imageUriString: String): Result<NearLatLng?>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/util/GetPagedImagesUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/util/GetPagedImagesUseCase.kt
@@ -1,0 +1,7 @@
+package com.wheretogo.domain.usecase.util
+
+import com.wheretogo.domain.model.util.MediaImage
+
+interface GetImagesPageUseCase {
+    suspend operator fun invoke(offset: Int, limit: Int): Result<List<MediaImage>>
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ room = "2.6.1"
 truth = "1.4.2"
 work = "2.9.1"
 androidx-test = "1.6.1"
+paging-common = "3.5.0"
+paging-compose = "3.5.0"
 
 # DI
 androidx-hilt = "1.2.0"
@@ -192,6 +194,8 @@ junit5-android-test-runner = { module = "de.mannodermaus.junit5:android-test-run
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
 cash-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 google-truth = { module = "com.google.truth:truth", version.ref = "truth" }
+androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging-common" }
+androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging-compose" }
 
 
 [bundles]

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.paging.common)
+    implementation(libs.androidx.paging.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
@@ -1,7 +1,6 @@
 package com.wheretogo.presentation
 
 import android.Manifest.permission.ACCESS_FINE_LOCATION
-import android.Manifest.permission.ACCESS_MEDIA_LOCATION
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
 import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
@@ -108,11 +107,7 @@ enum class AdMinSize(val widthDp: Int, val heightDp: Int) {
 
 
 sealed class AppPermission(val names: List<String>) {
-    data object LOCATION : AppPermission(buildList {
-        val api = Build.VERSION.SDK_INT
-        if (api >= 1) add(ACCESS_FINE_LOCATION)
-    })
-
+    data object LOCATION : AppPermission(listOf(ACCESS_FINE_LOCATION))
     data object MEDIA : AppPermission(
         buildList {
             val api = Build.VERSION.SDK_INT

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
@@ -1,6 +1,10 @@
 package com.wheretogo.presentation
 
 import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.ACCESS_MEDIA_LOCATION
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
 import android.os.Build
 import androidx.annotation.StringRes
 import androidx.credentials.exceptions.GetCredentialCancellationException
@@ -102,13 +106,21 @@ enum class AdMinSize(val widthDp: Int, val heightDp: Int) {
     Card(300, 600)
 }
 
+
 sealed class AppPermission(val names: List<String>) {
-    data object LOCATION : AppPermission(run {
-        val mutable = mutableListOf<String>()
+    data object LOCATION : AppPermission(buildList {
         val api = Build.VERSION.SDK_INT
-        if(api >= 1) mutable.add(ACCESS_FINE_LOCATION)
-        mutable.toList()
+        if (api >= 1) add(ACCESS_FINE_LOCATION)
     })
+
+    data object MEDIA : AppPermission(
+        buildList {
+            val api = Build.VERSION.SDK_INT
+            if (api >= 34) add(READ_MEDIA_VISUAL_USER_SELECTED)
+            if (api >= 33) add(READ_MEDIA_IMAGES)
+            if (api >= 16 && api < 33) add(READ_EXTERNAL_STORAGE)
+        }
+    )
 
     data object UNKNOWN : AppPermission(listOf("UNKNOWN"))
 
@@ -120,6 +132,7 @@ sealed class AppPermission(val names: List<String>) {
         fun valueOf(names: Set<String>): AppPermission {
             return when {
                 LOCATION.isEqual(names) -> LOCATION
+                MEDIA.isEqual(names) -> MEDIA
                 else -> UNKNOWN
             }
         }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
@@ -1,0 +1,413 @@
+package com.wheretogo.presentation.composable
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.wheretogo.presentation.AppPermission
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.effect.LifecycleDisposer
+import com.wheretogo.presentation.feature.MediaAccess
+import com.wheretogo.presentation.feature.checkFalseOrData
+import com.wheretogo.presentation.feature.openSetting
+import com.wheretogo.presentation.feature.requestPermission
+import com.wheretogo.presentation.model.PickerImage
+import com.wheretogo.presentation.viewmodel.MediaPickerUiEvent
+import com.wheretogo.presentation.viewmodel.MediaPickerViewModel
+import com.wheretogo.presentation.theme.Gray50
+import com.wheretogo.presentation.theme.WhereTogoTheme
+import com.wheretogo.presentation.theme.White100
+import kotlinx.coroutines.launch
+
+@Composable
+fun MediaPicker(
+    onPicked: (List<PickerImage>) -> Unit,
+    onNavigateBack: () -> Unit = {},
+    viewModel: MediaPickerViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val state by viewModel.uiState.collectAsState()
+    val pagingItems = viewModel.images.collectAsLazyPagingItems()
+    val coroutine = rememberCoroutineScope()
+
+    BackHandler {
+        onNavigateBack()
+    }
+
+    LifecycleDisposer { viewModel.lifecycleChange(it) }
+
+    LaunchedEffect(Unit) {
+        viewModel.setAccess(
+            checkFalseOrData(context, AppPermission.MEDIA) as? MediaAccess
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect {
+            when (it) {
+                MediaPickerUiEvent.RefreshPage -> {
+                    pagingItems.refresh()
+                }
+
+                MediaPickerUiEvent.RefreshAccess -> {
+                    viewModel.setAccess(
+                        checkFalseOrData(context, AppPermission.MEDIA) as? MediaAccess
+                    )
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(pagingItems.loadState.refresh) {
+        if (pagingItems.loadState.refresh is LoadState.NotLoading) {
+            val ids = (0 until pagingItems.itemCount)
+                .mapNotNull { pagingItems[it]?.id }
+                .toSet()
+            viewModel.refreshSelection(ids)
+        }
+    }
+
+    LaunchedEffect(pagingItems.loadState) {
+        val refresh = pagingItems.loadState.refresh
+        val append = pagingItems.loadState.append
+        val error= when {
+            refresh is LoadState.Error -> refresh.error
+            append is LoadState.Error -> append.error
+            else -> null
+        }
+        error?.let { viewModel.handleError(it) }
+    }
+
+    when (state.access) {
+        null -> DeniedView(
+            {
+                coroutine.launch {
+                    requestPermission(context, AppPermission.MEDIA)
+                }
+            },
+        )
+
+        MediaAccess.FULL,
+        MediaAccess.PARTIAL -> GalleryView(
+            access = state.access!!,
+            pagingItems = pagingItems,
+            selected = state.selected,
+            onToggle = viewModel::toggle,
+            onOpenPicker = {
+                coroutine.launch { requestPermission(context, AppPermission.MEDIA) }
+            },
+            onOpenSettings = {
+                coroutine.launch { openSetting(context, AppPermission.MEDIA) }
+            },
+            onConfirm = {
+                onPicked(it)
+                onNavigateBack()
+            },
+        )
+    }
+}
+
+@Composable
+private fun DeniedView(onRequestPermission: () -> Unit) {
+    LaunchedEffect(Unit) {
+        onRequestPermission()
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            stringResource(R.string.need_photo_permission),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onRequestPermission) { Text(stringResource(R.string.need_permission)) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GalleryView(
+    access: MediaAccess,
+    pagingItems: LazyPagingItems<PickerImage>,
+    selected: Set<Long>,
+    onToggle: (Long) -> Unit,
+    onOpenPicker: () -> Unit,
+    onOpenSettings: () -> Unit,
+    onConfirm: (List<PickerImage>) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.photo_select)) })
+        },
+        bottomBar = {
+            Surface(tonalElevation = 2.dp) {
+                Button(
+                    onClick = {
+                        val picked = (0 until pagingItems.itemCount)
+                            .mapNotNull { pagingItems[it] }
+                            .filter { it.id in selected }
+                        onConfirm(picked)
+                    },
+                    enabled = selected.isNotEmpty(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                ) {
+                    Text(stringResource(R.string.selected_count, selected.size))
+                }
+            }
+        },
+    ) { padding ->
+        Column(Modifier.padding(padding).background(
+            color = White100
+        )) {
+            when (access) {
+                MediaAccess.PARTIAL -> {
+                    AllowAllBanner(onOpenSettings)
+                    PartialBanner(onOpenPicker)
+                }
+                else -> {}
+            }
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(2.dp),
+            ) {
+                items(
+                    count = pagingItems.itemCount,
+                    key = { index -> pagingItems[index]?.id ?: index },
+                ) { index ->
+                    val image = pagingItems[index]
+                    if (image != null) {
+                        PhotoCell(
+                            image = image,
+                            isSelected = image.id in selected,
+                            onClick = { onToggle(image.id) },
+                        )
+                    } else {
+                        Box(
+                            Modifier
+                                .aspectRatio(1f)
+                                .padding(1.dp)
+                                .background(MaterialTheme.colorScheme.surfaceVariant),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AllowAllBanner(onOpenSettings: () -> Unit) {
+    Surface(
+        color = Gray50,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                stringResource(R.string.need_all_photo_permission),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.weight(1f),
+            )
+            Box(
+                modifier = Modifier
+                    .defaultMinSize(minWidth = 58.dp, minHeight = 36.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .clickable { onOpenSettings() }
+                    .padding(ButtonDefaults.TextButtonContentPadding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.button_setting),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PartialBanner(onRequestMore: () -> Unit) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Default.Info, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.show_photo_select),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    stringResource(R.string.show_photo_select_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            TextButton(onClick = onRequestMore) { Text(stringResource(R.string.more_add)) }
+        }
+    }
+}
+
+@Composable
+private fun PhotoCell(
+    image: PickerImage,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .padding(1.dp)
+            .clip(RoundedCornerShape(0.dp)),
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(image.uri)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxSize()
+                .clickableNoRipple(onClick),
+        )
+        if (isSelected) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.25f)),
+            )
+            Surface(
+                shape = RoundedCornerShape(50),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(5.dp)
+                    .size(20.dp),
+            ) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = stringResource(R.string.button_selected),
+                    tint = Color.White,
+                    modifier = Modifier.padding(2.dp),
+                )
+            }
+        }
+    }
+}
+
+private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier =
+    this.then(
+        Modifier.clickable(
+            interactionSource = mutableStateOf(
+                androidx.compose.foundation.interaction.MutableInteractionSource()
+            ).value,
+            indication = null,
+            onClick = onClick,
+        )
+    )
+
+@Composable
+private fun fakePagingItems(count: Int): LazyPagingItems<PickerImage> {
+    val items = (0 until count).map { PickerImage(id = it.toLong(), uri = android.net.Uri.EMPTY) }
+    return kotlinx.coroutines.flow.flowOf(androidx.paging.PagingData.from(items))
+        .collectAsLazyPagingItems()
+}
+
+@Preview(showBackground = true, name = "FULL")
+@Composable
+private fun GalleryViewFullPreview() {
+    WhereTogoTheme {
+        GalleryView(
+            access = MediaAccess.FULL,
+            pagingItems = fakePagingItems(9),
+            selected = setOf(0L, 2L, 5L),
+            onToggle = {},
+            onOpenPicker = {},
+            onOpenSettings = {},
+            onConfirm = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "PARTIAL")
+@Composable
+private fun GalleryViewPartialPreview() {
+    WhereTogoTheme {
+        GalleryView(
+            access = MediaAccess.PARTIAL,
+            pagingItems = fakePagingItems(6),
+            selected = setOf(0L, 3L),
+            onToggle = {},
+            onOpenPicker = {},
+            onOpenSettings = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
@@ -80,9 +80,7 @@ fun RootScreen(viewModel: RootViewModel = hiltViewModel()) {
                     }
 
                     is AppEvent.Permission -> {
-                        val isDenied = checkFalseOrData(context,it.permission) == false
-                        if (isDenied)
-                            multiplePermissionsLauncher.launch(it.permission.names.toTypedArray())
+                        multiplePermissionsLauncher.launch(it.permission.names.toTypedArray())
                     }
                     is AppEvent.SignInScreen -> {
                         viewModel.setSignInScreenVisible(true)

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/Permission.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/Permission.kt
@@ -39,30 +39,34 @@ suspend fun requestPermission(context: Context, permission: AppPermission): Bool
         )
 
         if (isNeedGuide) {
-            val strRes= when(permission){
-                AppPermission.LOCATION -> R.string.grant_location_permission
-                AppPermission.MEDIA -> R.string.grant_picture_permission
-                else -> R.string.grant_permission
-            }
-
-            val intentUri = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                data = Uri.fromParts("package", context.packageName, null)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }.toUri(Intent.URI_INTENT_SCHEME)
-
-            EventBus.send(
-                AppEvent.SnackBar(
-                    EventMsg(
-                        strRes = strRes,
-                        labelRes = R.string.setting_open,
-                        uri = intentUri
-                    )
-                )
-            )
+            openSetting(context,permission)
         }
         return false
     }
     return true
+}
+
+suspend fun openSetting(context: Context, permission: AppPermission){
+    val strRes= when(permission){
+        AppPermission.LOCATION -> R.string.grant_location_permission
+        AppPermission.MEDIA -> R.string.grant_picture_permission
+        else -> R.string.grant_permission
+    }
+
+    val intentUri = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }.toUri(Intent.URI_INTENT_SCHEME)
+
+    EventBus.send(
+        AppEvent.SnackBar(
+            EventMsg(
+                strRes = strRes,
+                labelRes = R.string.setting_open,
+                uri = intentUri
+            )
+        )
+    )
 }
 
 enum class MediaAccess { FULL, PARTIAL }

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/Permission.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/Permission.kt
@@ -17,44 +17,55 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 suspend fun requestPermission(context: Context, permission: AppPermission): Boolean {
-    val isDenied = checkFalseOrData(context, permission) == false
+    val check = checkFalseOrData(context, permission)
+    val isRetry = when (check) {
+        MediaAccess.PARTIAL -> true
+        false -> true
+        else -> false
+    }
 
-    if (isDenied) {
-        val isRejected = withContext(Dispatchers.IO) {
+    var isDenied = check == false
+
+    if(isRetry){
+        isDenied = withContext(Dispatchers.IO) {
             !EventBus.sendWithResult(AppEvent.Permission(permission))
         }
-        if (isRejected) {
-            val isNeedGuide = !ActivityCompat.shouldShowRequestPermissionRationale(
-                context as Activity,
-                permission.names.firstOrNull()?:return false
-            )
+    }
 
-            if (isNeedGuide) {
-                when(permission){
-                    else -> {
-                        val intentUri = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                            data = Uri.fromParts("package", context.packageName, null)
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }.toUri(Intent.URI_INTENT_SCHEME)
+    if (isDenied) {
+        val isNeedGuide = !ActivityCompat.shouldShowRequestPermissionRationale(
+            context as Activity,
+            permission.names.firstOrNull()?:return false
+        )
 
-                        EventBus.send(
-                            AppEvent.SnackBar(
-                                EventMsg(
-                                    strRes = R.string.grant_location_permission,
-                                    labelRes = R.string.setting_open,
-                                    uri = intentUri
-                                )
-                            )
-                        )
-                    }
-                }
-
+        if (isNeedGuide) {
+            val strRes= when(permission){
+                AppPermission.LOCATION -> R.string.grant_location_permission
+                AppPermission.MEDIA -> R.string.grant_picture_permission
+                else -> R.string.grant_permission
             }
-            return false
+
+            val intentUri = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }.toUri(Intent.URI_INTENT_SCHEME)
+
+            EventBus.send(
+                AppEvent.SnackBar(
+                    EventMsg(
+                        strRes = strRes,
+                        labelRes = R.string.setting_open,
+                        uri = intentUri
+                    )
+                )
+            )
         }
+        return false
     }
     return true
 }
+
+enum class MediaAccess { FULL, PARTIAL }
 
 fun checkFalseOrData(context: Context, appPermission: AppPermission): Any {
     if(appPermission.names.isEmpty())
@@ -63,6 +74,15 @@ fun checkFalseOrData(context: Context, appPermission: AppPermission): Any {
         ContextCompat.checkSelfPermission(context, p) == PackageManager.PERMISSION_GRANTED
     }
     return when (appPermission) {
+        AppPermission.MEDIA -> {
+            when {
+                granted(Manifest.permission.READ_MEDIA_IMAGES) -> MediaAccess.FULL
+                granted(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED) -> MediaAccess.PARTIAL
+                granted(Manifest.permission.READ_EXTERNAL_STORAGE) -> MediaAccess.FULL
+                else -> false
+            }
+        }
+
         else -> {
             appPermission.names.forEach {
                 if(!granted(it)) return false

--- a/presentation/src/main/java/com/wheretogo/presentation/model/PickerImage.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/PickerImage.kt
@@ -1,0 +1,19 @@
+package com.wheretogo.presentation.model
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.wheretogo.domain.model.util.MediaImage
+
+data class PickerImage(
+    val id: Long,
+    val uri: Uri,
+){
+    companion object{
+        fun MediaImage.toPickerImage(): PickerImage{
+            return PickerImage(
+                id = id,
+                uri = uriString.toUri()
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
@@ -9,12 +9,14 @@ val Pink80 = Color(0xFFEFB8C8)
 val Teal200 = Color(0xFF03DAC5)
 val Teal700 = Color(0xFF018786)
 
+val Blue30 = Color(0xFFD4E3FF)
 val Blue50 = Color(0xFFBAD2FA)
 val Blue100 = Color(0xFFA4C8FF)
 val Blue200 = Color(0xFF6895C2)
 val Blue300 = Color(0xFF0065BD)
 val Blue400 = Color(0xFF0046A7)
 val Blue500 = Color(0xFF182A56)
+val Blue600 = Color(0xFF214876)
 
 val PrimeBlue = Color(0xFF509BDC)
 

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
@@ -16,6 +16,9 @@ private val LightColorScheme = lightColorScheme(
     primary = Blue300,
     secondary = Blue100,
     tertiary = Pink80,
+    secondaryContainer = Blue30,
+    onSecondaryContainer = Blue600,
+    surface = White50
 )
 
 @Composable

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/DriveViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/DriveViewModel.kt
@@ -34,7 +34,7 @@ import com.wheretogo.domain.usecase.course.RemoveCourseUseCase
 import com.wheretogo.domain.usecase.report.ReportContentUseCase
 import com.wheretogo.domain.usecase.user.UserSignOutUseCase
 import com.wheretogo.domain.usecase.util.ClearCacheUseCase
-import com.wheretogo.domain.usecase.util.GetImageForPopupUseCase
+import com.wheretogo.domain.usecase.util.GetImageUseCase
 import com.wheretogo.domain.usecase.util.SearchKeywordUseCase
 import com.wheretogo.domain.usecase.util.UpdateLikeUseCase
 import com.wheretogo.presentation.AppError
@@ -107,7 +107,7 @@ class DriveViewModel @Inject constructor(
     private val handler: DriveHandler,
     private val observeSettingsUseCase: ObserveSettingsUseCase,
     private val getCommentForCheckPointUseCase: GetCommentForCheckPointUseCase,
-    private val getImageForPopupUseCase: GetImageForPopupUseCase,
+    private val getImageUseCase: GetImageUseCase,
     private val addCheckpointToCourseUseCase: AddCheckpointToCourseUseCase,
     private val addCommentToCheckPointUseCase: AddCommentToCheckPointUseCase,
     private val removeCourseUseCase: RemoveCourseUseCase,
@@ -443,7 +443,7 @@ class DriveViewModel @Inject constructor(
                     if (!isPrePatchIdx.contains(idx)) return@async item
                     val imageId = item.imageId
                     if (imageId.isNullOrBlank() || !item.url.isNullOrBlank()) return@async item
-                    val url = getImageForPopupUseCase(imageId)
+                    val url = getImageUseCase(imageId)
                     item.copy(url = url)
                 }
             }

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MediaPickerViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MediaPickerViewModel.kt
@@ -1,0 +1,122 @@
+package com.wheretogo.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.cachedIn
+import com.wheretogo.domain.usecase.util.GetImagesPageUseCase
+import com.wheretogo.presentation.AppLifecycle
+import com.wheretogo.presentation.feature.MediaAccess
+import com.wheretogo.presentation.model.PickerImage
+import com.wheretogo.presentation.model.PickerImage.Companion.toPickerImage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class MediaPickerUiState(
+    val access: MediaAccess? = null,
+    val selected: Set<Long> = emptySet(),
+    val confirmed: Boolean = false,
+)
+
+enum class MediaPickerUiEvent{
+    RefreshPage, RefreshAccess
+}
+
+@HiltViewModel
+class MediaPickerViewModel  @Inject constructor(
+    private val getImagesPage: GetImagesPageUseCase
+): ViewModel()  {
+    private val _uiState = MutableStateFlow(MediaPickerUiState())
+    private val _uiEvent = MutableSharedFlow<MediaPickerUiEvent>()
+    val uiState: StateFlow<MediaPickerUiState> = _uiState.asStateFlow()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    val images: Flow<PagingData<PickerImage>> =
+        Pager(
+            config = PagingConfig(
+                pageSize = 60,
+                prefetchDistance = 30,   // 끝 30칸 전부터 미리 로드
+                maxSize = 300,           // 멀리 벗어난 페이지는 회수
+                enablePlaceholders = false,
+            ),
+            pagingSourceFactory = { MediaPagingSource(getImagesPage) },
+        ).flow.cachedIn(viewModelScope)
+
+    fun toggle(id: Long) {
+        _uiState.update { state ->
+            val next = if (id in state.selected) state.selected - id
+            else state.selected + id
+            state.copy(selected = next)
+        }
+    }
+
+    fun handleError(error: Throwable) {
+
+    }
+
+    fun setAccess(access: MediaAccess?) {
+        _uiState.update { it.copy(access = access) }
+        if(access != null)
+            viewModelScope.launch {
+                println("tst_ $access")
+                _uiEvent.emit(MediaPickerUiEvent.RefreshPage)
+            }
+    }
+
+    fun lifecycleChange(event: AppLifecycle) {
+        when (event) {
+            AppLifecycle.onResume -> {
+                viewModelScope.launch {
+                    _uiEvent.emit(MediaPickerUiEvent.RefreshAccess)
+                }
+            }
+
+            else -> {}
+        }
+    }
+
+    fun refreshSelection(validIds: Set<Long>) {
+        _uiState.update { it.copy(selected = it.selected intersect validIds) }
+    }
+}
+
+
+class MediaPagingSource(
+    private val getImagesPage: GetImagesPageUseCase,
+) : PagingSource<Int, PickerImage>() {
+
+    override fun getRefreshKey(state: PagingState<Int, PickerImage>): Int? {
+        val anchor = state.anchorPosition ?: return null
+        val page = state.closestPageToPosition(anchor)
+        return page?.prevKey?.plus(1) ?: page?.nextKey?.minus(1)
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PickerImage> {
+        val offset = params.key ?: 0
+        val limit = params.loadSize
+        return try {
+            val images = getImagesPage(offset, limit)
+                .getOrThrow().map { it.toPickerImage() }
+            LoadResult.Page(
+                data = images,
+                prevKey = if (offset == 0) null else offset - limit,
+                nextKey = if (images.size < limit) null else offset + limit,
+            )
+
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -190,4 +190,16 @@
     <string name="cool_down_error">🏝️더 좋은 여행 정보를 위해 잠깐만 기다려 주세요.\n %s분 뒤에 다시 등록할 수 있어요.</string>
 
     <string name="blank" />
+
+    // 사진 권한
+    <string name="show_photo_select">선택한 사진 표시중</string>
+    <string name="show_photo_select_desc">새로운 사진을 추가하려면 버튼을 클릭하세요.</string>
+    <string name="need_photo_permission">사진을 불러오려면 접근 권한이 필요합니다</string>
+    <string name="need_all_photo_permission">전체 사진을 보려면 설정에서 접근 권한을 허용하세요.</string>
+    <string name="need_permission">권한 요청</string>
+    <string name="more_add">더 추가</string>
+    <string name="photo_select">사진 선택</string>
+    <string name="selected_count">선택 완료 (%1$d개)</string>
+    <string name="button_selected">선택됨</string>
+    <string name="button_setting">설정</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -75,7 +75,9 @@
 
 
     <string name="setting_open">설정열기</string>
+    <string name="grant_permission">권한 수락 하러 가기</string>
     <string name="grant_location_permission">내 위치 권한 수락 하러 가기</string>
+    <string name="grant_picture_permission">사진 접근 권한 수락 하러 가기</string>
 
 
     <string name="checkpoint">체크포인트</string>


### PR DESCRIPTION
### 1. 미디어 피커 화면 추가
- 권한 상태에 따라 화면 분기
- 그리드로 선택된, 전체 사진 표시
- 상단 배너로 추가 권한 허락 안내

## ✅ 테스트 항목
- [x] 사진 권한 요청버튼 클릭후 제한된 사진 선택시 선택된 사진만 표시되는지 확인
- [x] 사진 권한 요청버튼 클릭후 전체 사진 선택시 전체사진이 표시되는지 확인
- [x] 사진 권한 거절시 거절 화면 이동 및 설정 안내 토스트 표시 확인
- [x] 제한된 사진보기시 권한 설정 변경 안내 탑바 표시 확인
- [x] 제한된 사진보기시 선택중 탑바 표시 확인 
- [x] 미디어 선택후 전달된 사진 (로그) 확인 
