### PR TITLE
갤러리, 포토뷰어 페이지 추가

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -5,3 +5,4 @@
 /src/main/java/com/wheretogo/data/datasourceimpl/AuthRemoteDatasourceImpl.kt
 /src/main/java/com/wheretogo/data/feature/DataEncryptorImpl.kt
 /src/main/java/com/wheretogo/data/feature/SecureStore.kt
+/src/main/java/com/wheretogo/data/test/**

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -1,9 +1,10 @@
 package com.wheretogo.data.datasource
 
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
+import com.wheretogo.domain.model.util.MediaImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
 import java.io.File
 
 
@@ -11,7 +12,7 @@ interface ImageLocalDatasource {
 
     suspend fun getImage(imageId: String, size: ImageSize): File
 
-    suspend fun removeImage(imageId: String, size: ImageSize): Result<Unit>
+    suspend fun removeImage(imageId: String, size: ImageSize): Result<Boolean>
 
     suspend fun saveImage(byteArray: ByteArray, imageId: String, size: ImageSize): Result<File>
 
@@ -28,4 +29,10 @@ interface ImageLocalDatasource {
     suspend fun getPreview(imageUriString: String): Result<FilePreview>
 
     suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
+
+    suspend fun loadGalleyPhotos():Result<List<GalleryPhoto>>
+
+    suspend fun saveGalleryPhotos(uriStrings:List<String>): Result<List<Long>>
+
+    suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -18,22 +18,25 @@ import com.wheretogo.data.ImageFormat
 import com.wheretogo.data.datasource.ImageLocalDatasource
 import com.wheretogo.data.feature.PhotoExifReader
 import com.wheretogo.data.model.confg.ImageConfig
+import com.wheretogo.data.datasourceimpl.database.GalleryDatabase
+import com.wheretogo.data.model.gallery.PhotoEntity
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.feature.fit
-import com.wheretogo.domain.feature.rotate
-import com.wheretogo.domain.feature.scale
-import com.wheretogo.domain.feature.scaleCrop
-import com.wheretogo.domain.model.util.ExifData
-import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.feature.rotateByExif
 import com.wheretogo.domain.feature.scaleCropToFill
 import com.wheretogo.domain.feature.scaleToFitInside
 import com.wheretogo.domain.model.address.LatLng
+import com.wheretogo.domain.model.util.ExifData
+import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.MediaImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.gallery.PhotoExif
 import dagger.hilt.android.qualifiers.ApplicationContext
+import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
@@ -42,8 +45,10 @@ class ImageLocalDatasourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val imageFile: File,
     private val imageConfig: ImageConfig,
+    private val galleryDatabase: GalleryDatabase,
     private val exifReader: PhotoExifReader
 ) : ImageLocalDatasource {
+    private val photoDao by lazy { galleryDatabase.photoDao() }
     private val ext = imageConfig.format.ext
     private val mediaUri: Uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 
@@ -75,11 +80,12 @@ class ImageLocalDatasourceImpl @Inject constructor(
     }
 
 
-    override suspend fun removeImage(imageId: String, size: ImageSize): Result<Unit> {
+    override suspend fun removeImage(imageId: String, size: ImageSize): Result<Boolean> {
         return runCatching {
             val localFile = getImage(imageId, size)
             if (localFile.exists())
                 localFile.delete()
+            else true
         }
     }
 
@@ -175,13 +181,123 @@ class ImageLocalDatasourceImpl @Inject constructor(
 
     override suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>> {
         return runCatching {
-            queryImages(offset, limit)?.use { cursor ->
-                cursor.toMediaImages()
-            } ?: emptyList()
+            context.contentResolver
+                .query(offset, limit)
+                ?.toMediaImages()
+                ?:emptyList()
         }
     }
 
-    private fun queryImages(offset: Int, limit: Int): Cursor? {
+    override suspend fun saveGalleryPhotos(uriStrings: List<String>): Result<List<Long>> = runCatching {
+        val keyed = uriStrings.associateBy { buildExistingKey(it) }
+        val existing = photoDao.findExistingKeys(keyed.keys.toList()).toSet()
+        val targets = keyed.filterKeys { it !in existing }
+        if (targets.isEmpty()) return@runCatching emptyList()
+        val entities = createEntity(targets)
+        val rowIds = photoDao.insertAll(entities)
+
+        entities.filterIndexed { i, entity ->
+            val inserted = rowIds.getOrNull(i) != -1L
+            if (!inserted) {
+                ImageSize.entries.forEach { removeImage(entity.imageId, it) }
+            }
+            inserted
+        }.map { it.id }
+    }
+
+    override suspend fun loadGalleyPhotos(): Result<List<GalleryPhoto>> {
+        return runCatching {
+            photoDao.getAll().mapNotNull {
+                it.toGalleryPhoto(it.imageId)
+            }
+        }
+    }
+
+    private fun ContentResolver.createExifData(uriString: String): ExifData?{
+        val uri = uriString.toUri()
+        return openInputStream(uri)?.use { exifReader.read(it) }
+    }
+
+    suspend fun List<Pair<ImageSize, ByteArray>>.saveImages(imageId: String) : File {
+        return  coroutineScope {
+            map { (size, bytes) ->
+                async { saveImage(bytes, imageId, size).getOrThrow() }
+            }.awaitAll().first()
+        }
+    }
+
+    override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
+        return runCatching {
+            val removed= buildSet {
+                val photos= photoDao.getByIds(ids)
+                coroutineScope {
+                    photos.map { entity ->
+                        async {
+                            removeImage(entity.imageId, ImageSize.NORMAL).getOrNull()?:return@async
+                            removeImage(entity.imageId, ImageSize.SMALL).getOrNull()?:return@async
+                            add(entity.id)
+                        }
+                    }.awaitAll()
+                }
+            }
+
+            photoDao.deleteByIds(removed)
+            removed
+        }
+    }
+
+    private suspend fun createEntity(targets: Map<String, String>): List<PhotoEntity> {
+        val semaphore = Semaphore(10)
+        return coroutineScope {
+            targets.map { (sourceKey, uriString) ->
+                async {
+                    semaphore.withPermit {
+                        runCatching {
+                            val imageId = generateImageId()
+                            val exif = context.contentResolver.createExifData(uriString)
+                            val file = openAndResizeImage(uriString, ImageSize.entries)
+                                .getOrThrow()
+                                .saveImages(imageId)
+
+                            PhotoEntity(
+                                id = generateId(),
+                                imageId = imageId,
+                                fileName = file.name,
+                                sourceKey = sourceKey,
+                                dateTaken = exif?.timestampMillis,
+                                width = exif?.imageWidth,
+                                height = exif?.imageHeight,
+                                latitude = exif?.latitude,
+                                longitude = exif?.longitude,
+                            )
+                        }.getOrNull()
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+    }
+
+    private suspend fun PhotoEntity.toGalleryPhoto(imageId:String): GalleryPhoto? {
+        val uriString= getImage(imageId, ImageSize.NORMAL).toUri().path?:return null
+        val thumbnail= getImage(imageId, ImageSize.SMALL).toUri().path?:return null
+
+        return GalleryPhoto(
+            id = id,
+            imageId = imageId,
+            uriString = uriString,
+            thumbnail= thumbnail,
+            exif = PhotoExif(
+                dateTaken = dateTaken,
+                width = width,
+                height = height,
+                location = if (latitude != null && longitude != null)
+                    LatLng(latitude, longitude) else null,
+            ),
+        )
+    }
+
+
+    private fun ContentResolver.query(offset: Int, limit: Int): Cursor? {
         val projection = arrayOf(MediaStore.Images.Media._ID)
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val args = bundleOf(
@@ -190,20 +306,22 @@ class ImageLocalDatasourceImpl @Inject constructor(
                 ContentResolver.QUERY_ARG_LIMIT to limit,
                 ContentResolver.QUERY_ARG_OFFSET to offset,
             )
-            context.contentResolver.query(mediaUri, projection, args, null)
+            query(mediaUri, projection, args, null)
         } else {
             val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC LIMIT $limit OFFSET $offset"
-            context.contentResolver.query(mediaUri, projection, null, null, sortOrder)
+            query(mediaUri, projection, null, null, sortOrder)
         }
     }
 
     private fun Cursor.toMediaImages(): List<MediaImage> {
-        val idCol = getColumnIndexOrThrow(MediaStore.Images.Media._ID)
-        return buildList(count) {
-            while (moveToNext()) {
-                val id = getLong(idCol)
-                val uri = ContentUris.withAppendedId(mediaUri, id).toString()
-                add(MediaImage(id, uri))
+        return use { cursor ->
+            val idCol = getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            buildList(count) {
+                while (moveToNext()) {
+                    val id = getLong(idCol)
+                    val uri = ContentUris.withAppendedId(mediaUri, id).toString()
+                    add(MediaImage(id, uri))
+                }
             }
         }
     }
@@ -229,4 +347,17 @@ class ImageLocalDatasourceImpl @Inject constructor(
             canvas.drawRect(0f, 0f, width.toFloat(), width.toFloat(), paint)
         }
     }
+
+
+    private fun buildExistingKey(uriString: String): String =
+        uriString.toUri().lastPathSegment ?: uriString.toUri().toString()
+
+    private var lastId = 0L
+    private fun generateId(): Long {
+        val now = System.currentTimeMillis()
+        lastId = if (now <= lastId) lastId + 1 else now
+        return lastId
+    }
+
+    private fun generateImageId():String = "IM${ULID().nextULID()}"
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -25,6 +25,10 @@ import com.wheretogo.domain.feature.scale
 import com.wheretogo.domain.feature.scaleCrop
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
+import com.wheretogo.domain.feature.rotateByExif
+import com.wheretogo.domain.feature.scaleCropToFill
+import com.wheretogo.domain.feature.scaleToFitInside
+import com.wheretogo.domain.model.address.LatLng
 import com.wheretogo.domain.model.util.MediaImage
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
@@ -109,46 +113,39 @@ class ImageLocalDatasourceImpl @Inject constructor(
     override suspend fun openAndResizeImage(
         sourceUriString: String,
         sizeGroup: List<ImageSize>,
-        compressionQuality: Int
-    ): Result<List<Pair<ImageSize, ByteArray>>> {
+        compressionQuality: Int,
+    ): Result<List<Pair<ImageSize, ByteArray>>> = runCatching {
+        val uri = sourceUriString.toUri()
 
-        return runCatching {
-            val originalBitmap =
-                context.contentResolver.openInputStream(sourceUriString.toUri())
-                    ?.use { inputStream ->
-                        BitmapFactory.decodeStream(inputStream)
-                    }!!
+        val originalBitmap = context.contentResolver.openInputStream(uri)?.use { input ->
+            BitmapFactory.decodeStream(input)
+        } ?: error("이미지 로드 실패: $sourceUriString")
 
-            val exif =
-                context.contentResolver.openInputStream(sourceUriString.toUri())
-                    ?.use { inputStream ->
-                        ExifInterface(inputStream)
-                    }!!
+        val exif = context.contentResolver.openInputStream(uri)?.use { input ->
+            ExifInterface(input)
+        } ?: error("exif 로드 실패: $sourceUriString")
 
-            coroutineScope {
-                sizeGroup.map { size ->
-                    async {
-                        val newBitmap = originalBitmap
-                            .rotate(exif)
-                            .scale(size)
-                            .run {
-                                when (size) {
-                                    ImageSize.SMALL -> scaleCrop()
-                                    ImageSize.NORMAL -> fit(ImageSize.NORMAL)
-                                }
-                            }
+        val rotated = originalBitmap.rotateByExif(exif)
 
-                        size to ByteArrayOutputStream().use { stream ->
-                            newBitmap.compress(
-                                imageConfig.format.toCompressFormat(),
-                                compressionQuality,
-                                stream
-                            )
-                            stream.toByteArray()
-                        }
+        coroutineScope {
+            sizeGroup.map { size ->
+                async {
+                    val target = when (size) {
+                        ImageSize.SMALL -> rotated.scaleCropToFill(size)     // 꽉 채워 크롭
+                        ImageSize.NORMAL -> rotated.scaleToFitInside(size)   // 비율 유지 축소
                     }
-                }.awaitAll()
-            }
+
+                    val bytes = ByteArrayOutputStream().use { stream ->
+                        target.compress(
+                            imageConfig.format.toCompressFormat(),
+                            compressionQuality,
+                            stream,
+                        )
+                        stream.toByteArray()
+                    }
+                    size to bytes
+                }
+            }.awaitAll()
         }
     }
 

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
@@ -1,0 +1,49 @@
+package com.wheretogo.data.datasourceimpl.database
+
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.RoomDatabase
+import com.wheretogo.data.model.gallery.PhotoEntity
+import kotlinx.coroutines.flow.Flow
+
+@Database(entities = [PhotoEntity::class], version = 1, exportSchema = false)
+abstract class GalleryDatabase : RoomDatabase() {
+    abstract fun photoDao(): GalleryPhotoDao
+}
+
+
+@Dao
+interface GalleryPhotoDao {
+
+    @Insert(onConflict = OnConflictStrategy.Companion.IGNORE)
+    suspend fun insertAll(photos: List<PhotoEntity>): List<Long>
+
+    @Query(
+        """
+        SELECT * FROM gallery_photo
+        ORDER BY (dateTaken IS NULL), dateTaken DESC
+        """
+    )
+    suspend fun getAll(): List<PhotoEntity>
+
+    @Query("SELECT sourceKey FROM gallery_photo WHERE sourceKey IN (:keys)")
+    suspend fun findExistingKeys(keys: List<String>): List<String>
+
+    @Query("SELECT * FROM gallery_photo WHERE id IN (:ids)")
+    suspend fun getByIds(ids: Set<Long>): List<PhotoEntity>
+
+    @Query("DELETE FROM gallery_photo WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: Set<Long>)
+
+    // 흐름 관찰이 필요하면 추가 (확장용)
+    @Query(
+        """
+        SELECT * FROM gallery_photo
+        ORDER BY (dateTaken IS NULL), dateTaken DESC
+        """
+    )
+    fun observeAll(): Flow<List<PhotoEntity>>
+}

--- a/data/src/main/java/com/wheretogo/data/di/DaoDatabaseModule.kt
+++ b/data/src/main/java/com/wheretogo/data/di/DaoDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.wheretogo.data.datasourceimpl.database.CheckPointDatabase
 import com.wheretogo.data.datasourceimpl.database.CourseDatabase
 import com.wheretogo.data.datasourceimpl.database.RouteDatabase
+import com.wheretogo.data.datasourceimpl.database.GalleryDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -49,5 +50,15 @@ object DaoDatabaseModule {
         ).fallbackToDestructiveMigration()
             .build()
     }
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): GalleryDatabase =
+        Room.databaseBuilder(
+            context,
+            GalleryDatabase::class.java,
+            "gallery_db"
+        ).fallbackToDestructiveMigration()
+            .build()
 
 }

--- a/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
@@ -1,0 +1,21 @@
+package com.wheretogo.data.model.gallery
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "gallery_photo",
+    indices = [Index(value = ["sourceKey"], unique = true)],
+)
+data class PhotoEntity(
+    @PrimaryKey val id: Long,
+    val imageId: String,
+    val fileName: String,
+    val sourceKey: String,        // 중복 판단용
+    val dateTaken: Long?,
+    val width: Int?,
+    val height: Int?,
+    val latitude: Double?,
+    val longitude: Double?,
+)

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.repository.ImageRepository
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
+import com.wheretogo.domain.model.gallery.GalleryPhoto
 import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -25,6 +26,7 @@ class ImageRepositoryImpl @Inject constructor(
     private val imageRemoteDatasource: ImageRemoteDatasource,
     private val imageLocalDatasource: ImageLocalDatasource
 ) : ImageRepository {
+    private fun generateId():String = "IM${ULID().nextULID()}"
 
     override suspend fun getImage(imageId: String, size: ImageSize): Result<String> {
         return runCatching {
@@ -59,6 +61,18 @@ class ImageRepositoryImpl @Inject constructor(
         }.onFailure {
             coroutineScope { launch { removeImage(imageId) } }
         }.mapDataError().mapDomainError()
+    }
+
+    override suspend fun loadGalleyPhotos(): Result<List<GalleryPhoto>> {
+        return imageLocalDatasource.loadGalleyPhotos()
+    }
+
+    override suspend fun saveGalleryPhotos(imgUriStrings: List<String>): Result<List<Long>> {
+        return imageLocalDatasource.saveGalleryPhotos(imgUriStrings)
+    }
+
+    override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
+        return imageLocalDatasource.clearGalleryPhotos(ids)
     }
 
     override suspend fun removeImage(imageId: String): Result<Unit> {

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -43,8 +43,7 @@ class ImageRepositoryImpl @Inject constructor(
     }
 
     override suspend fun setImage(imgUriString: String): Result<ImageUris> {
-        val imageId = "IM${ULID().nextULID()}"
-
+        val imageId = generateId()
         return runCatching {
             val resizedImages =
                 imageLocalDatasource.openAndResizeImage(imgUriString, ImageSize.entries)

--- a/domain/.gitignore
+++ b/domain/.gitignore
@@ -1,2 +1,3 @@
 /build
 /src/main/java/com/wheretogo/domain/usecaseimpl/**
+/src/main/java/com/wheretogo/domain/test/**

--- a/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
@@ -1,5 +1,11 @@
 package com.wheretogo.domain.di
 
+import com.wheretogo.domain.usecase.gallery.DeleteGalleryPhotosUseCase
+import com.wheretogo.domain.usecaseimpl.gallery.DeleteGalleryPhotosUseCaseImpl
+import com.wheretogo.domain.usecase.gallery.LoadGalleryPhotosUseCase
+import com.wheretogo.domain.usecaseimpl.gallery.LoadGalleryPhotosUseCaseImpl
+import com.wheretogo.domain.usecase.gallery.SavePickedImagesUseCase
+import com.wheretogo.domain.usecaseimpl.gallery.SavePickedImagesUseCaseImpl
 import com.wheretogo.domain.usecase.app.AppCheckBySignatureUseCase
 import com.wheretogo.domain.usecase.app.DriveTutorialUseCase
 import com.wheretogo.domain.usecase.app.ObserveMsgUseCase
@@ -156,6 +162,15 @@ abstract class UseCaseModule {
 
     @Binds
     abstract fun bindGetImagesPageUseCase(useCaseImpl: GetImagesPageUseCaseImpl): GetImagesPageUseCase
+
+    @Binds
+    abstract fun bindSavePickedImagesUseCase(useCaseImpl: SavePickedImagesUseCaseImpl): SavePickedImagesUseCase
+
+    @Binds
+    abstract fun bindLoadGalleryPhotosUseCase(useCaseImpl: LoadGalleryPhotosUseCaseImpl): LoadGalleryPhotosUseCase
+
+    @Binds
+    abstract fun bindDeleteGalleryPhotosUseCase(useCaseImpl: DeleteGalleryPhotosUseCaseImpl): DeleteGalleryPhotosUseCase
 
 }
 

--- a/domain/src/main/java/com/wheretogo/domain/feature/BitmapScale.kt
+++ b/domain/src/main/java/com/wheretogo/domain/feature/BitmapScale.kt
@@ -1,64 +1,55 @@
 package com.wheretogo.domain.feature
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Matrix
-import android.graphics.Paint
 import androidx.exifinterface.media.ExifInterface
 import com.wheretogo.domain.ImageSize
-import androidx.core.graphics.createBitmap
 
+fun Bitmap.scaleToFitInside(size: ImageSize): Bitmap {
+    val scaleFactor = minOf(
+        size.width.toFloat() / width,
+        size.height.toFloat() / height,
+    ).coerceAtMost(1f)   // 업스케일 방지
 
-fun Bitmap.fit(size: ImageSize): Bitmap {
-    val squareBitmap = createBitmap(size.width, size.height)
-    val canvas = Canvas(squareBitmap)
-    val paint = Paint().apply { color = Color.BLACK }
-
-    canvas.drawRect(0f, 0f, size.width.toFloat(), size.height.toFloat(), paint)
-
-    val left = (size.width - this.width) / 2
-    val top = (size.height - this.height) / 2
-    canvas.drawBitmap(this, left.toFloat(), top.toFloat(), null)
-    return squareBitmap
+    val newW = (width * scaleFactor).toInt().coerceAtLeast(1)
+    val newH = (height * scaleFactor).toInt().coerceAtLeast(1)
+    if (newW == width && newH == height) return this
+    return Bitmap.createScaledBitmap(this, newW, newH, true)
 }
 
-fun Bitmap.scale(size: ImageSize): Bitmap {
-    val scaleFactor = if (width > height) {
-        size.width.toFloat() / width
-    } else {
-        size.height.toFloat() / height
-    }
+fun Bitmap.scaleCropToFill(size: ImageSize): Bitmap {
+    val scaleFactor = maxOf(
+        size.width.toFloat() / width,
+        size.height.toFloat() / height,
+    )
+    val scaledW = (width * scaleFactor).toInt().coerceAtLeast(size.width)
+    val scaledH = (height * scaleFactor).toInt().coerceAtLeast(size.height)
+    val scaled =
+        if (scaledW == width && scaledH == height) this
+        else Bitmap.createScaledBitmap(this, scaledW, scaledH, true)
 
-    val resizedWidth = (width * scaleFactor).toInt()
-    val resizedHeight = (height * scaleFactor).toInt()
-
-    return Bitmap.createScaledBitmap(this, resizedWidth, resizedHeight, true)
+    val xOffset = ((scaled.width - size.width) / 2).coerceAtLeast(0)
+    val yOffset = ((scaled.height - size.height) / 2).coerceAtLeast(0)
+    val cropW = size.width.coerceAtMost(scaled.width)
+    val cropH = size.height.coerceAtMost(scaled.height)
+    return Bitmap.createBitmap(scaled, xOffset, yOffset, cropW, cropH)
 }
 
-
-fun Bitmap.scaleCrop(): Bitmap {
-    val squareSize = minOf(width, height)
-    val xOffset = (width - squareSize) / 2
-    val yOffset = (height - squareSize) / 2
-    return Bitmap.createBitmap(this, xOffset, yOffset, squareSize, squareSize)
-}
-
-fun Bitmap.resize(size: ImageSize): Bitmap {
-    return Bitmap.createScaledBitmap(this, size.width, size.height, true)
-}
-
-fun Bitmap.rotate(exif: ExifInterface): Bitmap {
-    val rotate =
+fun Bitmap.rotateByExif(exif: ExifInterface): Bitmap {
+    val orientation =
         exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
 
-    val rotationDegrees = when (rotate) {
-        ExifInterface.ORIENTATION_ROTATE_90 -> 90
-        ExifInterface.ORIENTATION_ROTATE_180 -> 180
-        ExifInterface.ORIENTATION_ROTATE_270 -> 270
-        else -> 0
-    }
     val matrix = Matrix()
-    matrix.postRotate(rotationDegrees.toFloat())
-    return Bitmap.createBitmap(this, 0, 0, this.width, this.height, matrix, true)
+    when (orientation) {
+        ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+        ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+        ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+        ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.postScale(-1f, 1f)
+        ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.postScale(1f, -1f)
+        ExifInterface.ORIENTATION_TRANSPOSE -> { matrix.postRotate(90f); matrix.postScale(-1f, 1f) }
+        ExifInterface.ORIENTATION_TRANSVERSE -> { matrix.postRotate(270f); matrix.postScale(-1f, 1f) }
+        else -> return this   // NORMAL/UNDEFINED → 회전 불필요, 원본 반환
+    }
+    return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
 }
+

--- a/domain/src/main/java/com/wheretogo/domain/handler/GalleryFlowHandler.kt
+++ b/domain/src/main/java/com/wheretogo/domain/handler/GalleryFlowHandler.kt
@@ -1,0 +1,6 @@
+package com.wheretogo.domain.handler
+
+
+interface GalleryFlowHandler{
+    suspend fun handle(e: Throwable, msgEvent: GalleryFlowMsgEvent?=null)
+}

--- a/domain/src/main/java/com/wheretogo/domain/handler/ScreenEvents.kt
+++ b/domain/src/main/java/com/wheretogo/domain/handler/ScreenEvents.kt
@@ -20,3 +20,7 @@ enum class LoginEvent {
 enum class RootEvent {
     APP_CHECK_SUCCESS, USER_CHECK_SUCCESS, ACCOUNT_VALID_EXPIRE
 }
+
+enum class GalleryFlowMsgEvent {
+    GALLERY_LOAD_FAIL, MEDIA_SAVE_FAIL, PHOTO_DELETE_FAIL
+}

--- a/domain/src/main/java/com/wheretogo/domain/handler/ScreenEvents.kt
+++ b/domain/src/main/java/com/wheretogo/domain/handler/ScreenEvents.kt
@@ -6,7 +6,7 @@ enum class DriveMsgEvent {
 }
 
 enum class HomeEvent {
-    DRIVE_NAVIGATE, COURSE_ADD_NAVIGATE, GUIDE_START, GUIDE_STOP
+    DRIVE_NAVIGATE, COURSE_ADD_NAVIGATE, GALLERY_NAVIGATE, GUIDE_START, GUIDE_STOP
 }
 
 enum class CourseAddEvent {

--- a/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
@@ -1,0 +1,11 @@
+package com.wheretogo.domain.model.gallery
+
+data class GalleryPhoto(
+    val id: Long, // 시스템 picker id
+    val imageId: String = "",
+    val uriString: String,
+    val thumbnail:String = "",
+    val courseId:String? = null,
+    val courseName:String? = null,
+    val exif: PhotoExif,
+)

--- a/domain/src/main/java/com/wheretogo/domain/model/gallery/PhotoExif.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/gallery/PhotoExif.kt
@@ -1,0 +1,10 @@
+package com.wheretogo.domain.model.gallery
+
+import com.wheretogo.domain.model.address.LatLng
+
+data class PhotoExif(
+    val dateTaken: Long? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+    val location: LatLng? = null,
+)

--- a/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
@@ -1,16 +1,22 @@
 package com.wheretogo.domain.repository
 
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.model.util.ImageUris
-import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
+import com.wheretogo.domain.model.util.ImageUris
+import com.wheretogo.domain.model.util.MediaImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
 
 interface ImageRepository {
     suspend fun getImage(imageId: String, size: ImageSize): Result<String>
     suspend fun setImage(imgUriString: String): Result<ImageUris>
     suspend fun removeImage(imageId: String): Result<Unit>
+
     suspend fun getExif(imageUriString: String): Result<ExifData>
     suspend fun getPreview(imageUriString: String): Result<FilePreview>
     suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
+
+    suspend fun loadGalleyPhotos():Result<List<GalleryPhoto>>
+    suspend fun saveGalleryPhotos(imgUriStrings: List<String>): Result<List<Long>>
+    suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/gallery/DeleteGalleryPhotosUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/gallery/DeleteGalleryPhotosUseCase.kt
@@ -1,0 +1,5 @@
+package com.wheretogo.domain.usecase.gallery
+
+interface DeleteGalleryPhotosUseCase {
+    suspend operator fun invoke(ids: Set<Long>): Result<List<Long>>
+}

--- a/domain/src/main/java/com/wheretogo/domain/usecase/gallery/LoadGalleryPhotosUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/gallery/LoadGalleryPhotosUseCase.kt
@@ -1,0 +1,7 @@
+package com.wheretogo.domain.usecase.gallery
+
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+
+interface LoadGalleryPhotosUseCase {
+    suspend operator fun invoke(): Result<List<GalleryPhoto>>
+}

--- a/domain/src/main/java/com/wheretogo/domain/usecase/gallery/SavePickedImagesUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/gallery/SavePickedImagesUseCase.kt
@@ -1,0 +1,7 @@
+package com.wheretogo.domain.usecase.gallery
+
+import com.wheretogo.domain.model.util.MediaImage
+
+interface SavePickedImagesUseCase {
+    suspend operator fun invoke(images: List<MediaImage>): Result<List<Long>>
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6144m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -22,3 +22,5 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=true
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
@@ -96,6 +96,7 @@ sealed class AppScreen {
     data object Home : AppScreen()
     data object Drive : AppScreen()
     data object CourseAdd : AppScreen()
+    data object Gallery : AppScreen()
     data object Setting : AppScreen()
 }
 
@@ -147,7 +148,7 @@ enum class HomeBodyBtnHighlight {
 }
 
 enum class HomeBodyBtn {
-    DRIVE, COURSE_ADD, GUIDE, CREATER_REQUEST
+    DRIVE, COURSE_ADD, GALLERY, GUIDE, CREATER_REQUEST
 }
 
 enum class DriveBottomSheetContent(val minHeight: Int) {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/HomeScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/HomeScreen.kt
@@ -129,7 +129,7 @@ fun Body(homeBodyBtnHighlight: HomeBodyBtnHighlight, onClick: (HomeBodyBtn) -> U
     val isActive = homeBodyBtnHighlight == HomeBodyBtnHighlight.NONE
     Column(verticalArrangement = Arrangement.spacedBy(gridGap)) {
         GridButton(
-            3, 2,
+            row = 3,
             isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.DRIVE,
             isActive = isActive,
             click = { onClick(HomeBodyBtn.DRIVE) }
@@ -142,22 +142,41 @@ fun Body(homeBodyBtnHighlight: HomeBodyBtnHighlight, onClick: (HomeBodyBtn) -> U
             )
         }
 
-        GridButton(
-            3, 2,
-            isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.COURSE_ADD,
-            isActive = isActive,
-            click = { onClick(HomeBodyBtn.COURSE_ADD) }
-        ) {
-            ContentTextImage(
-                stringResource(R.string.course_add_main),
-                stringResource(R.string.course_add_sub),
-                0.dp,
-                null
-            )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(gridGap)){
+            GridButton(
+                modifier = Modifier.weight(1f),
+                row = 3,
+                isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.COURSE_ADD,
+                isActive = isActive,
+                click = { onClick(HomeBodyBtn.COURSE_ADD) }
+            ) {
+                ContentTextImage(
+                    stringResource(R.string.course_add_main),
+                    stringResource(R.string.course_add_sub),
+                    0.dp,
+                    null
+                )
+            }
+            GridButton(
+                modifier = Modifier.weight(1f),
+                row = 3,
+                isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.COURSE_ADD,
+                isActive = isActive,
+                click = { onClick(HomeBodyBtn.GALLERY) }
+            ) {
+                ContentTextImage(
+                    stringResource(R.string.gallery_main),
+                    stringResource(R.string.gallery_sub),
+                    0.dp,
+                    null
+                )
+            }
+
         }
 
         GridButton(
-            2, 2,
+            row = 2,
             isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.GUIDE,
             isActive = isActive,
             click = {
@@ -170,7 +189,7 @@ fun Body(homeBodyBtnHighlight: HomeBodyBtnHighlight, onClick: (HomeBodyBtn) -> U
             )
         }
         GridButton(
-            5, 2,
+            row = 5,
             isHighlight = homeBodyBtnHighlight == HomeBodyBtnHighlight.CREATER_REQUEST,
             isActive = isActive,
             click = {
@@ -200,7 +219,7 @@ data class BodyContent(
 @Composable
 fun GridButton(
     row: Int,
-    col: Int,
+    modifier: Modifier = Modifier,
     isHighlight: Boolean = false,
     isActive: Boolean = true,
     click: () -> Unit,
@@ -208,7 +227,7 @@ fun GridButton(
 ) {
     val isConsume = !isActive && !isHighlight
     Surface(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(row * 40.dp)
             .clip(shape = RoundedCornerShape(10.dp))
@@ -218,7 +237,7 @@ fun GridButton(
         color = Palette.White,
     ) {
         content()
-        if(isConsume)
+        if (isConsume)
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -331,9 +350,8 @@ fun BodyPreview() {
 fun GridButtonPreview() {
     Surface(modifier = Modifier.width(400.dp)) {
         GridButton(
-            2,
-            2,
-            false,
+            row = 2,
+            isHighlight = false,
             isActive = true,
             content = { ContentTextImage("메인", "서브", 0.dp, R.raw.lt_togeter) },
             click = {})
@@ -344,7 +362,9 @@ fun GridButtonPreview() {
 @Composable
 fun GrindBannerPreview() {
     Surface(modifier = Modifier.width(400.dp)) {
-        GridButton(4, 2, content = {
+        GridButton(
+            row = 4,
+            content = {
             ContentBanner(
                 stringResource(R.string.banner_main),
                 stringResource(R.string.banner_sub)

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
@@ -36,6 +36,7 @@ import com.wheretogo.presentation.feature.EventBus
 import com.wheretogo.presentation.feature.checkFalseOrData
 import com.wheretogo.presentation.feature.openUri
 import com.wheretogo.presentation.feature.show
+import com.wheretogo.presentation.composable.gallery.GalleryFlow
 import com.wheretogo.presentation.theme.Palette
 import com.wheretogo.presentation.theme.WhereTogoTheme
 import com.wheretogo.presentation.viewmodel.RootViewModel
@@ -160,7 +161,7 @@ fun RootScreen(viewModel: RootViewModel = hiltViewModel()) {
                         enterTransition = { slideInHorizontally(initialOffsetX = { it }) },
                         exitTransition = { slideOutHorizontally(targetOffsetX = { it }) }
                     ) {
-                        GalleryScreen()
+                        GalleryFlow()
                     }
                     composable(setting,
                         enterTransition = { slideInHorizontally(initialOffsetX = { it }) },

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/RootScreen.kt
@@ -137,6 +137,7 @@ fun RootScreen(viewModel: RootViewModel = hiltViewModel()) {
                 val home = AppScreen.Home.toString()
                 val drive = AppScreen.Drive.toString()
                 val courseAdd = AppScreen.CourseAdd.toString()
+                val gallery = AppScreen.Gallery.toString()
                 val setting = AppScreen.Setting.toString()
 
                 NavHost(navController = navController, startDestination = home) {
@@ -155,6 +156,12 @@ fun RootScreen(viewModel: RootViewModel = hiltViewModel()) {
                     ) {
                          CourseAddScreen()
                      }
+                    composable(gallery,
+                        enterTransition = { slideInHorizontally(initialOffsetX = { it }) },
+                        exitTransition = { slideOutHorizontally(targetOffsetX = { it }) }
+                    ) {
+                        GalleryScreen()
+                    }
                     composable(setting,
                         enterTransition = { slideInHorizontally(initialOffsetX = { it }) },
                         exitTransition = { slideOutHorizontally(targetOffsetX = { it }) }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryFlow.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryFlow.kt
@@ -1,0 +1,58 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wheretogo.presentation.viewmodel.GalleryFlowViewModel
+import com.wheretogo.presentation.intent.GalleryIntent
+
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun GalleryFlow(
+    viewModel: GalleryFlowViewModel = hiltViewModel(),
+) {
+    val selectedPhoto by viewModel.detailPhoto.collectAsState()
+    val gridState = rememberLazyGridState()
+
+    SharedTransitionLayout(
+        modifier = Modifier.navigationBarsPadding(),
+    ) {
+        AnimatedContent(
+            targetState = selectedPhoto,
+            label = "galleryFlow",
+            transitionSpec = {
+                fadeIn(tween(300)) togetherWith
+                fadeOut(tween(300))
+            },
+        ) { photo ->
+            if (photo == null) {
+                GalleryScreen(
+                    sharedScope = this@SharedTransitionLayout,
+                    animatedScope = this@AnimatedContent,
+                    gridState = gridState,
+                    onPhotoOpen = { viewModel.handleIntent(GalleryIntent.OpenDetail(it.id)) },
+                    viewModel = viewModel,
+                )
+            } else {
+                PhotoViewerScreen(
+                    photo = photo,
+                    sharedScope = this@SharedTransitionLayout,
+                    animatedScope = this@AnimatedContent,
+                    onClose = { viewModel.handleIntent(GalleryIntent.CloseDetail) },
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
@@ -1,0 +1,509 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.MediaPicker
+import com.wheretogo.presentation.feature.GroupingStrategy
+import com.wheretogo.presentation.model.PhotoSection
+import com.wheretogo.presentation.state.GalleryState
+import com.wheretogo.presentation.viewmodel.GalleryFlowViewModel
+import com.wheretogo.presentation.intent.GalleryIntent
+
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun GalleryScreen(
+    sharedScope:SharedTransitionScope,
+    animatedScope: AnimatedVisibilityScope,
+    gridState: LazyGridState,
+    onPhotoOpen: (GalleryPhoto) -> Unit,
+    viewModel: GalleryFlowViewModel,
+) {
+    val uiState by viewModel.galleryState.collectAsStateWithLifecycle()
+    var showPicker by rememberSaveable { mutableStateOf(false) }
+    var showGroupingSheet by rememberSaveable { mutableStateOf(false) }
+
+    if (showPicker) {
+        MediaPicker(
+            onPicked = { picked ->
+                showPicker = false
+                viewModel.handleIntent(GalleryIntent.MediaPicked(picked))
+            },
+            onNavigateBack = { showPicker = false },
+        )
+        return
+    }
+
+    val state = uiState
+    val isSelectionMode = state is GalleryState.Success && state.isSelectionMode
+
+    BackHandler(enabled = isSelectionMode) { viewModel.handleIntent(GalleryIntent.ClearSelection) }
+
+    Scaffold(
+        floatingActionButton = {
+            if (!isSelectionMode) {
+                FloatingActionButton(onClick = { showPicker = true }) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.photo_add))
+                }
+            }
+        },
+    ) { padding ->
+        Box(Modifier
+            .fillMaxSize()
+            .padding(padding)) {
+            Column(Modifier.fillMaxSize()) {
+
+                if (state is GalleryState.Success) {
+                    GalleryTopArea(
+                        selectionMode = isSelectionMode,
+                        groupingLabel = state.groupingLabel,
+                        sheetExpanded = showGroupingSheet,
+                        allSelected = state.allPhotos.isNotEmpty() &&
+                                state.selectedIds.size == state.allPhotos.size,
+                        onGroupingButtonClick = { showGroupingSheet = true },
+                        onToggleSelectAll = {
+                            if (state.selectedIds.size == state.allPhotos.size)
+                                viewModel.handleIntent(GalleryIntent.ClearSelection)
+                            else
+                                viewModel.handleIntent(GalleryIntent.SelectAll)
+                        },
+                    )
+                }
+
+                Box(Modifier.fillMaxSize()) {
+                    when (state) {
+                        is GalleryState.Loading ->
+                            LoadingMessageScreen()
+                        is GalleryState.Error ->
+                            Column(Modifier.align(Alignment.Center), horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(state.message)
+                                TextButton(
+                                    onClick = { viewModel.handleIntent(GalleryIntent.Refresh) }
+                                ) { Text(stringResource(R.string.retry)) }
+                            }
+                        is GalleryState.Success ->
+                            PhotoGrid(
+                                sections = state.sections,
+                                selectedIds = state.selectedIds,
+                                selectionMode = state.isSelectionMode,
+                                gridState = gridState,
+                                sharedScope = sharedScope,
+                                animatedScope = animatedScope,
+                                onPhotoClick = { photo ->
+                                    val s = uiState as? GalleryState.Success
+                                    if (s?.isSelectionMode == true)
+                                        viewModel.handleIntent(GalleryIntent.PhotoClick(photo.id))
+                                    else
+                                        onPhotoOpen(photo)
+                                },
+                                onPhotoLongClick = {
+                                    viewModel.handleIntent(GalleryIntent.PhotoLongClick(it.id))
+                                },
+                            )
+                    }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = isSelectionMode,
+                enter = slideInVertically { it } + fadeIn(),
+                exit = slideOutVertically { it } + fadeOut(),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                val s = state as? GalleryState.Success
+                SelectionActionBar(
+                    selectedCount = s?.selectedIds?.size ?: 0,
+                    onDelete = { viewModel.handleIntent(GalleryIntent.DeleteSelected) },
+                )
+            }
+        }
+    }
+
+    if (showGroupingSheet) {
+        GroupingBottomSheet(
+            options = viewModel.groupings,
+            currentLabel = viewModel.currentGroupingLabel,
+            onSelect = {
+                viewModel.handleIntent(GalleryIntent.ChangeGrouping(it))
+                showGroupingSheet = false
+            },
+            onDismiss = { showGroupingSheet = false },
+        )
+    }
+}
+
+@Composable
+private fun GalleryTopArea(
+    selectionMode: Boolean,
+    groupingLabel: String,
+    sheetExpanded: Boolean,
+    allSelected: Boolean,
+    onGroupingButtonClick: () -> Unit,
+    onToggleSelectAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val fadeAlpha by animateFloatAsState(if (selectionMode) 1f else 0f)
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 8.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        GroupHeader(
+            modifier = Modifier.graphicsLayer { alpha = 1f - fadeAlpha },
+            groupingLabel = groupingLabel,
+            selectionMode = selectionMode,
+            sheetExpanded = sheetExpanded,
+            onGroupingButtonClick = onGroupingButtonClick
+        )
+        SelectHeader(
+            modifier = Modifier.graphicsLayer { alpha = fadeAlpha },
+            selectionMode = selectionMode,
+            allSelected = allSelected,
+            onToggleSelectAll = onToggleSelectAll
+        )
+    }
+}
+
+@Composable
+private fun GroupHeader(
+    modifier: Modifier,
+    groupingLabel: String,
+    selectionMode: Boolean,
+    sheetExpanded: Boolean,
+    onGroupingButtonClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .then(if (!selectionMode) Modifier.clickable(onClick = onGroupingButtonClick) else Modifier)
+            .padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(groupingLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        val direction by animateFloatAsState(if (sheetExpanded) 180f else 0f)
+        Icon(
+            Icons.Default.KeyboardArrowDown, contentDescription = null,
+            modifier = Modifier
+                .padding(start = 2.dp)
+                .graphicsLayer { rotationZ = direction },
+        )
+    }
+}
+
+@Composable
+private fun SelectHeader(modifier: Modifier, selectionMode: Boolean, allSelected: Boolean, onToggleSelectAll:()->Unit){
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(stringResource(R.string.select_ing), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.weight(1f))
+        TextButton(onClick = onToggleSelectAll, enabled = selectionMode) {
+            Text(if (allSelected) stringResource(R.string.release_all) else stringResource(R.string.select_all))
+        }
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun PhotoGrid(
+    modifier: Modifier = Modifier,
+    sections: List<PhotoSection>,
+    selectedIds: Set<Long>,
+    selectionMode: Boolean,
+    gridState: LazyGridState,
+    sharedScope: SharedTransitionScope,
+    animatedScope: AnimatedVisibilityScope,
+    onPhotoClick: (GalleryPhoto) -> Unit,
+    onPhotoLongClick: (GalleryPhoto) -> Unit,
+) {
+    LazyVerticalGrid(
+        state = gridState,
+        columns = GridCells.Adaptive(minSize = 110.dp),
+        contentPadding = PaddingValues(2.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        modifier = modifier.fillMaxSize(),
+    ) {
+        sections.forEach { section ->
+            item(key = "header_${section.key}", span = { GridItemSpan(maxLineSpan) }) {
+                SectionHeader(section.title)
+            }
+            items(section.photos, key = { it.id }) { photo ->
+                PhotoCell(
+                    modifier = Modifier.animateItem(),
+                    photo = photo,
+                    selected = photo.id in selectedIds,
+                    selectionMode = selectionMode,
+                    sharedScope = sharedScope,
+                    animatedScope = animatedScope,
+                    onClick = { onPhotoClick(photo) },
+                    onLongClick = { onPhotoLongClick(photo) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
+    Text(
+        title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 4.dp, top = 16.dp, bottom = 6.dp),
+    )
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun PhotoCell(
+    modifier: Modifier = Modifier,
+    photo: GalleryPhoto,
+    selected: Boolean,
+    selectionMode: Boolean,
+    sharedScope: SharedTransitionScope,
+    animatedScope: AnimatedVisibilityScope,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    val haptic = LocalHapticFeedback.current
+    val scale by animateFloatAsState(if (selected) 0.88f else 1f)
+
+    Box(
+        modifier = modifier
+            .aspectRatio(1f)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onLongClick()
+                },
+            ),
+    ) {
+        with(sharedScope) {
+            AsyncImage(
+                model = photo.thumbnail,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .sharedElement(
+                        rememberSharedContentState(key = photo.id),
+                        animatedVisibilityScope = animatedScope,
+                    )
+                    .graphicsLayer { scaleX = scale; scaleY = scale }
+                    .clip(RoundedCornerShape(if (selected) 10.dp else 4.dp)),
+            )
+        }
+
+        if (selected) {
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .graphicsLayer { scaleX = scale; scaleY = scale }
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color.Black.copy(alpha = 0.25f))
+            )
+        }
+        if (photo.exif.location != null && !selectionMode) {
+            LocationBadge(Modifier
+                .align(Alignment.TopEnd)
+                .padding(4.dp))
+        }
+        if (selectionMode) {
+            SelectionCheck(selected, Modifier
+                .align(Alignment.TopStart)
+                .padding(4.dp))
+        }
+    }
+}
+
+@Composable
+private fun LocationBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(22.dp)
+            .background(Color.Black.copy(alpha = 0.45f), CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(Icons.Default.LocationOn, null, tint = Color.White, modifier = Modifier.size(14.dp))
+    }
+}
+
+@Composable
+private fun SelectionCheck(selected: Boolean, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(22.dp)
+            .clip(CircleShape)
+            .background(if (selected) MaterialTheme.colorScheme.primary else Color.Black.copy(alpha = 0.35f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) Icon(Icons.Default.Check, null, tint = Color.White, modifier = Modifier.size(14.dp))
+    }
+}
+
+@Composable
+private fun SelectionActionBar(
+    selectedCount: Int,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showConfirm by rememberSaveable { mutableStateOf(false) }
+
+    Surface(modifier = modifier.fillMaxWidth(), shadowElevation = 12.dp, color = MaterialTheme.colorScheme.surface) {
+        Row(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                stringResource(R.string.count_selected, selectedCount), style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = { showConfirm = true },
+                enabled = selectedCount > 0,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+            ) {
+                Icon(Icons.Default.Delete, null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+                Text(stringResource(R.string.delete))
+            }
+        }
+    }
+
+    if (showConfirm) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text(stringResource(R.string.request_count_delete, selectedCount)) },
+            text = { Text(stringResource(R.string.no_restore_photo_delete)) },
+            confirmButton = {
+                TextButton(onClick = { showConfirm = false; onDelete() }) {
+                    Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text(stringResource(R.string.cancel)) } },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GroupingBottomSheet(
+    options: List<GroupingStrategy>,
+    currentLabel: String,
+    onSelect: (GroupingStrategy) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 24.dp)) {
+            Text(stringResource(R.string.how_show), style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold, modifier = Modifier.padding(vertical = 12.dp))
+            options.forEach { strategy ->
+                val isSelect = strategy.label == currentLabel
+                GroupingStrategyItem(strategy = strategy, isSelect = isSelect, onSelect = onSelect)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupingStrategyItem(
+    strategy: GroupingStrategy,
+    isSelect: Boolean,
+    onSelect: (GroupingStrategy) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onSelect(strategy) }
+            .padding(vertical = 16.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(strategy.label, style = MaterialTheme.typography.titleMedium,
+            fontWeight = if (isSelect) FontWeight.Bold else FontWeight.Normal, modifier = Modifier.weight(1f))
+        if (isSelect) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.primary)
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/LoadingMessageScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/LoadingMessageScreen.kt
@@ -1,0 +1,169 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.annotation.ArrayRes
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.theme.WhereTogoTheme
+import kotlinx.coroutines.delay
+
+@Composable
+fun LoadingMessageScreen(
+    modifier: Modifier = Modifier,
+    messageIntervalMs: Long = 1400L,
+    @ArrayRes messages: Int = R.array.gallery_loading
+) {
+    val messages = stringArrayResource(messages).toList()
+    var messageIndex by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(messageIntervalMs) {
+        while (true) {
+            delay(messageIntervalMs)
+            messageIndex = (messageIndex + 1) % messages.size
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+
+            Box(modifier = Modifier.size(64.dp), contentAlignment = Alignment.Center) {
+                BouncingDotsIndicator()
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Box(
+                modifier = Modifier
+                    .height(48.dp)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                AnimatedLoadingMessage(
+                    message = messages[messageIndex],
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnimatedLoadingMessage(message: String) {
+    val textStyle = MaterialTheme.typography.bodyLarge.copy(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium
+    )
+    val textColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f)
+
+    AnimatedContent(
+        targetState = message,
+        transitionSpec = {
+            slideInVertically(tween(350, easing = FastOutSlowInEasing)) { it } +
+                    fadeIn(tween(350)) togetherWith
+            slideOutVertically(tween(350, easing = FastOutSlowInEasing)) { -it } +
+                    fadeOut(tween(250))
+        }
+    ) { msg ->
+        Message(msg, textStyle, textColor)
+    }
+}
+
+@Composable
+private fun Message(text: String, style: TextStyle, color: Color) {
+    Text(
+        text = text,
+        style = style,
+        color = color,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun BouncingDotsIndicator(
+    dotSize: Int = 10,
+    dotColor: Color = MaterialTheme.colorScheme.primary
+) {
+    val transition = rememberInfiniteTransition(label = "bouncingDots")
+    val delays = listOf(0, 150, 300)
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        delays.forEach { delayMs ->
+            val offsetY by transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 0f,
+                animationSpec = infiniteRepeatable(
+                    animation = keyframes {
+                        durationMillis = 900
+                        0f at delayMs using FastOutSlowInEasing
+                        -12f at delayMs + 150 using FastOutSlowInEasing
+                        0f at delayMs + 300
+                        0f at 900
+                    },
+                    repeatMode = RepeatMode.Restart
+                )
+            )
+            Box(
+                modifier = Modifier
+                    .size(dotSize.dp)
+                    .graphicsLayer { translationY = offsetY.dp.toPx() }
+                    .background(dotColor, CircleShape)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Loading - Static Message")
+@Composable
+private fun LoadingScreenPreviewStatic() {
+    WhereTogoTheme {
+        LoadingMessageScreen()
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/PhotoViewerScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/PhotoViewerScreen.kt
@@ -1,0 +1,226 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.gallery.PhotoExif
+import com.wheretogo.presentation.R
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun PhotoViewerScreen(
+    photo: GalleryPhoto,
+    sharedScope: SharedTransitionScope,
+    animatedScope: AnimatedVisibilityScope,
+    onClose: () -> Unit,
+    settingsContent: @Composable (GalleryPhoto) -> Unit = { DefaultPhotoSettings(it) },
+) {
+    val density = LocalDensity.current
+    val window = LocalWindowInfo.current
+    val photoHeightIn = calculateHeightIn(window,photo.exif)
+    val heightInScrollState = remember(photoHeightIn.max) { HeightInScrollState(photoHeightIn) }
+    val photoHeight by animateFloatAsState(
+        targetValue = heightInScrollState.targetHeight,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessLow),
+        label = "photoHeight",
+    )
+
+    BackHandler { onClose() }
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .nestedScroll(heightInScrollState.connection),
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(with(density) { photoHeight.toDp() })
+                    .clipToBounds(),
+                contentAlignment = Alignment.Center,
+            ) {
+                with(sharedScope) {
+                    AsyncImage(
+                        model = photo.uriString,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .sharedElement(
+                                rememberSharedContentState(key = photo.id),
+                                animatedVisibilityScope = animatedScope,
+                            ),
+                    )
+                }
+            }
+
+            Surface(
+                color = MaterialTheme.colorScheme.surface,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                settingsContent(photo)
+            }
+        }
+
+        IconButton(
+            onClick = onClose,
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(8.dp)
+                .align(Alignment.TopStart),
+        ) {
+            Icon(Icons.Default.Close, contentDescription = "닫기", tint = Color.White)
+        }
+    }
+}
+
+@Stable
+private class HeightInScrollState(
+    val heightIn: HeightIn,
+    private val followRatio: Float = 0.75f, // 스크롤 양 조절
+) {
+    var targetHeight by mutableFloatStateOf(heightIn.base)
+        private set
+
+    val connection = object : NestedScrollConnection {
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            // 위로 스크롤시에만
+            if (available.y >= 0f) return Offset.Zero
+            // 타겟 확장
+            return Offset(0f, consumeAndResize(available.y))
+        }
+
+        override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+            // 아래로 스크롤시에만
+            if (available.y <= 0f) return Offset.Zero
+            // 타겟 축소
+            return Offset(0f, consumeAndResize(available.y))
+        }
+    }
+
+    private fun consumeAndResize(delta: Float): Float {
+        val resizeHeight = (targetHeight + delta * followRatio) // 보정된 스크롤
+            .coerceIn(heightIn.min, heightIn.max) // 타겟의 최소, 최댓값 지정
+        val consumedHeight = resizeHeight - targetHeight
+        targetHeight = resizeHeight
+        return consumedHeight / followRatio  // 원본 단위로 환산
+    }
+}
+
+@Composable
+private fun DefaultPhotoSettings(photo: GalleryPhoto) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(stringResource(R.string.detail_info), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+
+        photo.exif.dateTaken?.let { ts ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.KOREA).format(Date(ts)),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+
+        photo.exif.location?.let { loc ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    "%.4f, %.4f".format(loc.latitude, loc.longitude),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+private data class HeightIn(val base: Float, val min: Float, val max: Float)
+
+@Composable
+private fun calculateHeightIn(window: WindowInfo ,exif: PhotoExif): HeightIn {
+    val containerWidth = window.containerSize.width.toFloat()
+    val containerHeight = window.containerSize.height.toFloat()
+    val base = minOf(containerWidth, containerHeight * 0.7f) // 진입시 크기
+    val min = base * 0.5f // 최소 높이가 진입시 크기의 50%
+    // 최대 높이가 사진의 비율과 컨테이너 크기의 82% 중 작은값
+    val max = remember(exif, containerWidth, containerHeight, base) {
+        val exifWidth = exif.width ?: 0
+        val exifHeight = exif.height ?: 0
+        val photoRatio = if (exifWidth > 0 && exifHeight > 0) {
+             exifHeight.toFloat() / exifWidth
+        } else {
+            1.3f
+        }
+        val heightByContainer = (containerHeight * 0.82f)
+        val heightByPhoto = containerWidth * photoRatio
+        minOf(heightByContainer,heightByPhoto).coerceAtLeast(base)
+    }
+    return HeightIn(base, min, max)
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/di/HandlerModule.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/di/HandlerModule.kt
@@ -3,12 +3,14 @@ package com.wheretogo.presentation.di
 import com.wheretogo.domain.handler.CourseAddHandler
 import com.wheretogo.domain.handler.DriveHandler
 import com.wheretogo.domain.handler.ErrorHandler
+import com.wheretogo.domain.handler.GalleryFlowHandler
 import com.wheretogo.domain.handler.HomeHandler
 import com.wheretogo.domain.handler.LoginHandler
 import com.wheretogo.domain.handler.RootHandler
 import com.wheretogo.presentation.handler.CourseAddHandlerImpl
 import com.wheretogo.presentation.handler.DefaultErrorHandlerImpl
 import com.wheretogo.presentation.handler.DriveHandlerImpl
+import com.wheretogo.presentation.handler.GalleryFlowHandlerImpl
 import com.wheretogo.presentation.handler.HomeHandlerImpl
 import com.wheretogo.presentation.handler.LoginHandlerImpl
 import com.wheretogo.presentation.handler.RootHandlerImpl
@@ -37,6 +39,9 @@ class HandlerModule {
 
     @Provides
     fun provideLoginHandler(error: ErrorHandler): LoginHandler = LoginHandlerImpl(error)
+
+    @Provides
+    fun provideGalleryFLowHandler(error: ErrorHandler): GalleryFlowHandler = GalleryFlowHandlerImpl(error)
 
     @Provides
     @Singleton

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
@@ -1,0 +1,52 @@
+package com.wheretogo.presentation.feature
+
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.presentation.model.PhotoSection
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+interface GroupingStrategy {
+    // 그룹 이름
+    val label: String
+
+    // 그룹간 순서
+    val comparator: Comparator<GalleryPhoto>
+
+    // 그룹 기준
+    fun keyOf(photo: GalleryPhoto): String
+
+    // 그룹 표시
+    fun titleOf(key: String, sample: GalleryPhoto): String
+}
+
+fun List<GalleryPhoto>.toSections(strategy: GroupingStrategy): List<PhotoSection> =
+    this.sortedWith(strategy.comparator)
+        .groupBy { strategy.keyOf(it) }
+        .map { (key, photos) ->
+            PhotoSection(key = key, title = strategy.titleOf(key, photos.first()), photos = photos)
+        }
+
+class ByDayGrouping : GroupingStrategy {
+
+    override val label: String = "날짜별"
+
+    override val comparator: Comparator<GalleryPhoto> =
+        compareByDescending<GalleryPhoto> { it.exif.dateTaken != null }
+            .thenByDescending { it.exif.dateTaken ?: Long.MIN_VALUE }
+
+    override fun keyOf(photo: GalleryPhoto): String {
+        val ts = photo.exif.dateTaken ?: return KEY_UNKNOWN
+        return dayKeyFormat.format(Date(ts))
+    }
+
+    override fun titleOf(key: String, sample: GalleryPhoto): String =
+        if (key == KEY_UNKNOWN) "날짜 없음"
+        else titleFormat.format(Date(sample.exif.dateTaken!!))
+
+    private companion object {
+        const val KEY_UNKNOWN = "unknown"
+        val dayKeyFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+        val titleFormat = SimpleDateFormat("yyyy년 M월 d일", Locale.KOREA)
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/handler/GalleryFlowHandlerImpl.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/handler/GalleryFlowHandlerImpl.kt
@@ -1,0 +1,24 @@
+package com.wheretogo.presentation.handler
+
+import com.wheretogo.domain.handler.ErrorHandler
+import com.wheretogo.domain.handler.GalleryFlowHandler
+import com.wheretogo.domain.handler.GalleryFlowMsgEvent
+import com.wheretogo.presentation.AppEvent
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.feature.EventBus
+import com.wheretogo.presentation.model.EventMsg
+
+class GalleryFlowHandlerImpl(val errorHandler: ErrorHandler) : GalleryFlowHandler {
+    override suspend fun handle(e: Throwable, msgEvent: GalleryFlowMsgEvent?) {
+        when(msgEvent){
+            GalleryFlowMsgEvent.GALLERY_LOAD_FAIL ->
+                EventBus.send(AppEvent.SnackBar(EventMsg(R.string.gallery_load_fail)))
+            GalleryFlowMsgEvent.MEDIA_SAVE_FAIL ->
+                EventBus.send(AppEvent.SnackBar(EventMsg(R.string.media_save_fail)))
+            GalleryFlowMsgEvent.PHOTO_DELETE_FAIL ->
+                EventBus.send(AppEvent.SnackBar(EventMsg(R.string.photo_delete_fail)))
+            else -> {}
+        }
+        errorHandler.handle(e)
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/handler/HomeHandlerImpl.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/handler/HomeHandlerImpl.kt
@@ -27,6 +27,14 @@ class HomeHandlerImpl() : HomeHandler {
                 )
             )
 
+            HomeEvent.GALLERY_NAVIGATE -> EventBus.send(
+                AppEvent.Navigation(
+                    AppScreen.Home,
+                    AppScreen.Gallery,
+                    false
+                )
+            )
+
             HomeEvent.GUIDE_START -> EventBus.send(AppEvent.SnackBar(EventMsg(R.string.tutorial_start)))
             HomeEvent.GUIDE_STOP -> EventBus.send(AppEvent.SnackBar(EventMsg(R.string.tutorial_stop)))
         }

--- a/presentation/src/main/java/com/wheretogo/presentation/intent/GalleryIntent.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/intent/GalleryIntent.kt
@@ -1,0 +1,17 @@
+package com.wheretogo.presentation.intent
+
+import com.wheretogo.presentation.feature.GroupingStrategy
+import com.wheretogo.presentation.model.PickerImage
+
+sealed interface GalleryIntent {
+    data object Refresh : GalleryIntent
+    data class MediaPicked(val images: List<PickerImage>) : GalleryIntent
+    data class ChangeGrouping(val strategy: GroupingStrategy) : GalleryIntent
+    data class OpenDetail(val id: Long) : GalleryIntent
+    data object CloseDetail : GalleryIntent
+    data class PhotoClick(val pickerId: Long) : GalleryIntent
+    data class PhotoLongClick(val pickerId: Long) : GalleryIntent
+    data object ClearSelection : GalleryIntent
+    data object SelectAll : GalleryIntent
+    data object DeleteSelected : GalleryIntent
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/model/PhotoSection.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/PhotoSection.kt
@@ -1,0 +1,9 @@
+package com.wheretogo.presentation.model
+
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+
+data class PhotoSection(
+    val key: String,
+    val title: String,
+    val photos: List<GalleryPhoto>,
+)

--- a/presentation/src/main/java/com/wheretogo/presentation/model/PickerImage.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/PickerImage.kt
@@ -7,13 +7,20 @@ import com.wheretogo.domain.model.util.MediaImage
 data class PickerImage(
     val id: Long,
     val uri: Uri,
-){
-    companion object{
-        fun MediaImage.toPickerImage(): PickerImage{
+) {
+    companion object {
+        fun MediaImage.toPickerImage(): PickerImage {
             return PickerImage(
                 id = id,
                 uri = uriString.toUri()
             )
         }
+    }
+
+    fun toMarkerImage(): MediaImage {
+        return MediaImage(
+            id = id,
+            uri.toString()
+        )
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/state/GalleryState.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/state/GalleryState.kt
@@ -1,0 +1,31 @@
+package com.wheretogo.presentation.state
+
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.presentation.model.PhotoSection
+
+sealed interface GalleryState {
+    data object Loading : GalleryState
+    data class Success(
+        val sections: List<PhotoSection> = emptyList(),
+        val selectedIds: Set<Long> = emptySet(),
+        val groupingLabel: String = "",
+    ) : GalleryState {
+        val isSelectionMode: Boolean get() = selectedIds.isNotEmpty()
+        val allPhotos: List<GalleryPhoto> get() = sections.flatMap { it.photos }
+    }
+    data class Error(val message: String) : GalleryState
+
+    suspend fun<T> onSuccessAwait(callback: suspend (Success)-> T): T?{
+        return if(this is Success)
+            callback(this)
+        else
+            null
+    }
+
+    fun<T> onSuccess(callback: (Success)-> T): T?{
+        return if(this is Success)
+            callback(this)
+        else
+            null
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
@@ -14,11 +14,14 @@ import androidx.core.view.WindowCompat
 
 private val LightColorScheme = lightColorScheme(
     primary = Palette.Blue300,
-    secondary = Palette.Blue50,
+    secondary = Palette.Blue100,
     tertiary = Palette.Pink80,
+    primaryContainer = Palette.White100,
     secondaryContainer = Palette.Blue30,
     onSecondaryContainer = Palette.Blue600,
-    surface = Palette.White50
+    surface = Palette.White50,
+    surfaceContainerLow = Palette.White100,
+    background = Palette.White100
 )
 
 @Composable

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
@@ -1,0 +1,200 @@
+package com.wheretogo.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wheretogo.domain.handler.GalleryFlowHandler
+import com.wheretogo.domain.handler.GalleryFlowMsgEvent
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.usecase.gallery.DeleteGalleryPhotosUseCase
+import com.wheretogo.domain.usecase.gallery.LoadGalleryPhotosUseCase
+import com.wheretogo.domain.usecase.gallery.SavePickedImagesUseCase
+import com.wheretogo.presentation.MainDispatcher
+import com.wheretogo.presentation.feature.ByDayGrouping
+import com.wheretogo.presentation.feature.GroupingStrategy
+import com.wheretogo.presentation.feature.toSections
+import com.wheretogo.presentation.intent.GalleryIntent
+import com.wheretogo.presentation.model.PickerImage
+import com.wheretogo.presentation.state.GalleryState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+
+sealed interface GalleryUiEffect {
+    data class NavigateToDetail(val photoId: Long) : GalleryUiEffect
+}
+
+@HiltViewModel
+class GalleryFlowViewModel @Inject constructor(
+    @MainDispatcher private val dispatcher: CoroutineDispatcher,
+    private val handler: GalleryFlowHandler,
+    private val savePickedImagesUseCase: SavePickedImagesUseCase,
+    private val loadGalleryPhotos: LoadGalleryPhotosUseCase,
+    private val deleteGalleryPhotos: DeleteGalleryPhotosUseCase,
+) : ViewModel() {
+    private val _galleyState =
+        MutableStateFlow<GalleryState>(GalleryState.Loading)
+    val galleryState: StateFlow<GalleryState> = _galleyState.asStateFlow()
+
+    private val _effect = MutableSharedFlow<GalleryUiEffect>()
+    val effect: SharedFlow<GalleryUiEffect> = _effect.asSharedFlow()
+
+    val groupings: List<GroupingStrategy> = listOf(ByDayGrouping())
+    private var _grouping: GroupingStrategy = groupings.first()
+    val currentGroupingLabel: String get() = _grouping.label
+
+    private var _cachedPhotos: List<GalleryPhoto> = emptyList()
+    private val _detailPhotoId = MutableStateFlow<Long?>(null)
+    val detailPhoto: StateFlow<GalleryPhoto?> = _detailPhotoId
+        .map { id -> id?.let { selectedId -> _cachedPhotos.firstOrNull { it.id == selectedId } } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    init {
+        initSuccess()
+        viewModelScope.launch(dispatcher) {
+            withContext(Dispatchers.IO){
+                delay(350)
+                handleIntent(GalleryIntent.Refresh)
+            }
+        }
+    }
+
+    fun handleIntent(intent: GalleryIntent) {
+        viewModelScope.launch(dispatcher) {
+            when (intent) {
+                is GalleryIntent.Refresh -> refreshGallery()
+                is GalleryIntent.MediaPicked -> onMediaPicked(intent.images)
+
+                is GalleryIntent.ChangeGrouping -> changeGrouping(intent.strategy)
+                is GalleryIntent.PhotoClick -> onPhotoClick(intent.pickerId)
+                is GalleryIntent.PhotoLongClick -> onPhotoLongClick(intent.pickerId)
+                is GalleryIntent.ClearSelection -> clearSelection()
+                is GalleryIntent.SelectAll -> selectAll()
+                is GalleryIntent.DeleteSelected -> deleteSelected()
+
+                is GalleryIntent.OpenDetail -> openDetail(intent.id)
+                is GalleryIntent.CloseDetail -> closeDetail()
+            }
+        }
+    }
+
+    suspend fun handleError(e: Throwable, event: GalleryFlowMsgEvent?=null){
+        handler.handle(e,event)
+    }
+
+    // 갤러리 갱신
+    private suspend fun onMediaPicked(images: List<PickerImage>) {
+        if (images.isEmpty()) return
+        _galleyState.value = GalleryState.Loading
+        val mediaImages = images.map { it.toMarkerImage() }
+        withContext(Dispatchers.IO) { savePickedImagesUseCase(mediaImages) }
+            .onSuccess { refreshGallery() }
+            .onFailure { handleError(it, GalleryFlowMsgEvent.MEDIA_SAVE_FAIL) }
+
+    }
+
+    private suspend fun refreshGallery() {
+        withContext(Dispatchers.IO) { loadGalleryPhotos() }
+            .onSuccess { photos ->
+                _cachedPhotos = photos
+                initSuccess()
+            }.onFailure {
+                _galleyState.value = GalleryState.Error("")
+                handleError(it, GalleryFlowMsgEvent.GALLERY_LOAD_FAIL)
+            }
+    }
+
+
+    // 갤러리 로드 성공시
+    private fun changeGrouping(strategy: GroupingStrategy) {
+        if (strategy.label == _grouping.label) return
+        _galleyState.value.onSuccess {
+            _grouping = strategy
+            initSuccess(selectedIds =  it.selectedIds)
+        }
+    }
+
+    private suspend fun onPhotoClick(pickerId: Long) {
+        _galleyState.value.onSuccessAwait {
+            if (it.isSelectionMode) {
+                it.toggleSelection(pickerId)
+            } else {
+                _effect.emit(GalleryUiEffect.NavigateToDetail(pickerId))
+            }
+        }
+    }
+
+    private fun onPhotoLongClick(pickerId: Long) {
+        _galleyState.value.onSuccess {
+            it.toggleSelection(pickerId)
+        }
+    }
+
+    private fun clearSelection() {
+        _galleyState.value.onSuccess {
+            _galleyState.value = it.copy(selectedIds = emptySet())
+        }
+    }
+
+    private fun selectAll() {
+        _galleyState.value.onSuccess {
+            _galleyState.value = it.copy(selectedIds = it.allPhotos.map { it.id }.toSet())
+        }
+    }
+
+    private suspend fun deleteSelected() {
+        _galleyState.value.onSuccessAwait {
+            val targets = it.selectedIds
+            if (targets.isEmpty()) return@onSuccessAwait
+            withContext(Dispatchers.IO) { deleteGalleryPhotos(targets) }
+                .onSuccess { deletedIds ->
+                    _cachedPhotos = _cachedPhotos.filterNot { it.id in deletedIds }
+                    initSuccess()
+                }.onFailure {
+                    handleError(it, GalleryFlowMsgEvent.PHOTO_DELETE_FAIL)
+                }
+        }
+    }
+
+    // 상세화면
+    private suspend fun openDetail(id: Long) {
+        _detailPhotoId.emit(id)
+    }
+
+    private suspend fun closeDetail() {
+        _detailPhotoId.emit(null)
+    }
+
+
+
+    // 헬퍼
+    private fun initSuccess(selectedIds: Set<Long> = emptySet()) {
+        val sections = _cachedPhotos.toSections(_grouping)
+        val validSelected = selectedIds intersect _cachedPhotos.map { it.id }.toSet()
+        _galleyState.value = GalleryState.Success(
+            sections = sections,
+            selectedIds = validSelected,
+            groupingLabel = _grouping.label,
+        )
+    }
+
+    private fun GalleryState.Success.toggleSelection(id: Long) {
+        val newSelected = selectedIds.toMutableSet().apply {
+            if (!add(id)) remove(id)
+        }
+        _galleyState.value = copy(selectedIds = newSelected)
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/HomeViewModel.kt
@@ -57,6 +57,10 @@ class HomeViewModel @Inject constructor(
                 handler.handle(HomeEvent.COURSE_ADD_NAVIGATE)
             }
 
+            HomeBodyBtn.GALLERY -> {
+                handler.handle(HomeEvent.GALLERY_NAVIGATE)
+            }
+
             HomeBodyBtn.GUIDE -> {
                 if (_uiState.value.guideState.tutorialStep == DriveTutorialStep.SKIP) {
                     handler.handle(HomeEvent.GUIDE_START)

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MediaPickerViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MediaPickerViewModel.kt
@@ -70,7 +70,6 @@ class MediaPickerViewModel  @Inject constructor(
         _uiState.update { it.copy(access = access) }
         if(access != null)
             viewModelScope.launch {
-                println("tst_ $access")
                 _uiEvent.emit(MediaPickerUiEvent.RefreshPage)
             }
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -204,4 +204,30 @@
     <string name="selected_count">선택 완료 (%1$d개)</string>
     <string name="button_selected">선택됨</string>
     <string name="button_setting">설정</string>
+
+    // 갤러리
+    <string name="photo_delete_fail">사진을 삭제하지 못했어요</string>
+    <string name="gallery_load_fail">사진을 불러오지 못했어요</string>
+    <string name="media_save_fail">사진을 옮기지 못했어요</string>
+    <string name="photo_add">사진 추가</string>
+    <string name="photo_add_guide">사진을 추가해 주세요</string>
+    <string name="retry">다시 시도</string>
+    <string name="select_ing">선택중</string>
+    <string name="release_all">전체 해제</string>
+    <string name="select_all">전체 선택</string>
+    <string name="count_selected">%1$d장 선택</string>
+    <string name="delete">삭제</string>
+    <string name="request_count_delete">%1$d장을 삭제할까요?</string>
+    <string name="no_restore_photo_delete">삭제한 사진은 복구할 수 없어요.</string>
+    <string name="cancel">취소</string>
+    <string name="how_show">어떻게 볼까요?</string>
+    <string name="detail_info">상세 정보</string>
+
+    <string-array name="gallery_loading">
+        <item>사진을 안전한 곳에 차곡차곡 담는 중…</item>
+        <item>위치 정보를 지우는중…</item>
+        <item>마지막 한 장까지 확인하는 중…</item>
+        <item>사진을 사용하는 것에 대한 허락을 구하는 것을 묻는 것에 대한 승인을 요구하는중…</item>
+    </string-array>
+
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="ranking_sub">지금 떠오르는 코스는?</string>
     <string name="course_add_main">코스등록</string>
     <string name="course_add_sub">나만의 코스를 공유해요</string>
+    <string name="gallery_main">스팟 갤러리</string>
+    <string name="gallery_sub">순간을 기록해요</string>
     <string name="bookmark_main">즐겨찾기</string>
     <string name="bookmark_sub">나의 추억들</string>
     <string name="sports_main">스포츠</string>


### PR DESCRIPTION
### 1. 갤러리 페이지 추가
- 사용자가 가져온 사진을 그룹별(날짜별)로 표시
- 사진 클릭시 포토뷰어로 이동
- 가져온 사진 삭제

### 2. 포토뷰어 페이지 추가
- 상단 사진영역에서 사진 표시
- 하단 정보영역 스크롤시 사진 확대,축소

## ✅ 테스트 항목
### 갤러리
- [x] 사진 가져오기후 날짜별로 표시되는지 확인
- [x] 사진 클릭시 포토뷰어 페이지 이동 확인
- [x] 사진 길게 클릭후 선택 토글 활성화 확인
- [x] 선택 토글 활성화시 전체 선택, 삭제 버튼 표시 확인
- [x] 삭제 버튼 클릭시 선택된 사진이 삭제되는지 확인
- [x] 모두 선택 해제시 선택 토글 비활성화 확인 

### 포토뷰어
- [x] 갤러리에서 선택된 사진이 이어서 표시되는지 확인
- [x] 하단 시트 위로 스크롤시 사진이 축소되는지 확인
- [x] 하단 시트 아래로 스크롤시 사진이 확대되는지 확인
