### PR TITLE
이미지 동시 변환시 메모리 부족 오류 수정

### DIFF
--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -1,5 +1,6 @@
 package com.wheretogo.data.datasource
 
+import com.wheretogo.data.model.gallery.EncodedImage
 import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
@@ -22,7 +23,7 @@ interface ImageLocalDatasource {
         sourceUriString: String,
         sizeGroup: List<ImageSize>,
         compressionQuality: Int = 80
-    ): Result<List<Pair<ImageSize, ByteArray>>>
+    ): Result<EncodedImage>
 
     suspend fun getExif(imageUriString: String): Result<ExifData>
 

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -5,7 +5,6 @@ import android.content.ContentUris
 import android.content.Context
 import android.database.Cursor
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -13,23 +12,25 @@ import android.provider.OpenableColumns
 import androidx.core.graphics.createBitmap
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
-import androidx.exifinterface.media.ExifInterface
 import com.wheretogo.data.ImageFormat
 import com.wheretogo.data.datasource.ImageLocalDatasource
-import com.wheretogo.data.feature.PhotoExifReader
-import com.wheretogo.data.model.confg.ImageConfig
 import com.wheretogo.data.datasourceimpl.database.GalleryDatabase
+import com.wheretogo.data.feature.PhotoExifReader
+import com.wheretogo.data.feature.downSampling
+import com.wheretogo.data.feature.exif
+import com.wheretogo.data.feature.rotateByExif
+import com.wheretogo.data.feature.scaleCropToFill
+import com.wheretogo.data.feature.scaleToFitInside
+import com.wheretogo.data.model.confg.ImageConfig
+import com.wheretogo.data.model.gallery.EncodedImage
 import com.wheretogo.data.model.gallery.PhotoEntity
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.feature.rotateByExif
-import com.wheretogo.domain.feature.scaleCropToFill
-import com.wheretogo.domain.feature.scaleToFitInside
 import com.wheretogo.domain.model.address.LatLng
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.gallery.PhotoExif
 import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.MediaImage
-import com.wheretogo.domain.model.gallery.GalleryPhoto
-import com.wheretogo.domain.model.gallery.PhotoExif
 import dagger.hilt.android.qualifiers.ApplicationContext
 import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
@@ -120,39 +121,36 @@ class ImageLocalDatasourceImpl @Inject constructor(
         sourceUriString: String,
         sizeGroup: List<ImageSize>,
         compressionQuality: Int,
-    ): Result<List<Pair<ImageSize, ByteArray>>> = runCatching {
+    ): Result<EncodedImage> = runCatching {
         val uri = sourceUriString.toUri()
+        val resolver = context.contentResolver
+        val exif = resolver.exif(uri)
 
-        val originalBitmap = context.contentResolver.openInputStream(uri)?.use { input ->
-            BitmapFactory.decodeStream(input)
-        } ?: error("이미지 로드 실패: $sourceUriString")
+        val maxBound = sizeGroup.maxOf { maxOf(it.width, it.height) }
+        val decoded = resolver.downSampling(uri, maxBound)
+        val rotated = decoded.rotateByExif(exif)
+        
+        if(rotated != decoded) decoded.recycle()
 
-        val exif = context.contentResolver.openInputStream(uri)?.use { input ->
-            ExifInterface(input)
-        } ?: error("exif 로드 실패: $sourceUriString")
+        val images = sizeGroup.associateWith { size ->
+            val target = when (size) {
+                ImageSize.SMALL -> rotated.scaleCropToFill(size)
+                ImageSize.NORMAL -> rotated.scaleToFitInside(size)
+            }
 
-        val rotated = originalBitmap.rotateByExif(exif)
+            val bytes = ByteArrayOutputStream().use { stream ->
+                target.compress(imageConfig.format.toCompressFormat(), compressionQuality, stream)
+                stream.toByteArray()
+            }
 
-        coroutineScope {
-            sizeGroup.map { size ->
-                async {
-                    val target = when (size) {
-                        ImageSize.SMALL -> rotated.scaleCropToFill(size)     // 꽉 채워 크롭
-                        ImageSize.NORMAL -> rotated.scaleToFitInside(size)   // 비율 유지 축소
-                    }
+            if (target != rotated) target.recycle()
 
-                    val bytes = ByteArrayOutputStream().use { stream ->
-                        target.compress(
-                            imageConfig.format.toCompressFormat(),
-                            compressionQuality,
-                            stream,
-                        )
-                        stream.toByteArray()
-                    }
-                    size to bytes
-                }
-            }.awaitAll()
+            bytes
         }
+
+        rotated.recycle()
+
+        EncodedImage(images = images)
     }
 
     override suspend fun getExif(imageUriString: String): Result<ExifData> {
@@ -218,7 +216,7 @@ class ImageLocalDatasourceImpl @Inject constructor(
         return openInputStream(uri)?.use { exifReader.read(it) }
     }
 
-    suspend fun List<Pair<ImageSize, ByteArray>>.saveImages(imageId: String) : File {
+    suspend fun Map<ImageSize, ByteArray>.saveImages(imageId: String) : File {
         return  coroutineScope {
             map { (size, bytes) ->
                 async { saveImage(bytes, imageId, size).getOrThrow() }
@@ -257,6 +255,7 @@ class ImageLocalDatasourceImpl @Inject constructor(
                             val exif = context.contentResolver.createExifData(uriString)
                             val file = openAndResizeImage(uriString, ImageSize.entries)
                                 .getOrThrow()
+                                .images
                                 .saveImages(imageId)
 
                             PhotoEntity(

--- a/data/src/main/java/com/wheretogo/data/di/ConfigModule.kt
+++ b/data/src/main/java/com/wheretogo/data/di/ConfigModule.kt
@@ -2,6 +2,7 @@ package com.wheretogo.data.di
 
 import com.wheretogo.data.ImageFormat
 import com.wheretogo.data.model.confg.ImageConfig
+import com.wheretogo.domain.ImageSize
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,14 +12,22 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ConfigModule {
-
+    private const val MAX_DOWN_MB = 10
     @Provides
     @Singleton
     fun provideImageConfig(): ImageConfig {
         return ImageConfig(
             format = ImageFormat.WEBP,
-            maxDownMB = 10
+            maxDownMB = MAX_DOWN_MB,
+            maxBitmapStreamCount = calculateStreamCount()
         )
     }
+    private fun calculateStreamCount(): Int {
+        val maxBound = ImageSize.entries.maxOf { maxOf(it.width, it.height) }
+        val runtime = Runtime.getRuntime()
+        val budgetBytes = runtime.maxMemory() / 5
 
+        val streamBytes = maxBound * maxBound * 2 // 안전 마진
+        return (budgetBytes / streamBytes).toInt().coerceIn(1, 12)
+    }
 }

--- a/data/src/main/java/com/wheretogo/data/feature/BitmapScale.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/BitmapScale.kt
@@ -1,7 +1,11 @@
-package com.wheretogo.domain.feature
+package com.wheretogo.data.feature
 
+import android.content.ContentResolver
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Matrix
+import android.net.Uri
+import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import com.wheretogo.domain.ImageSize
 
@@ -22,17 +26,13 @@ fun Bitmap.scaleCropToFill(size: ImageSize): Bitmap {
         size.width.toFloat() / width,
         size.height.toFloat() / height,
     )
-    val scaledW = (width * scaleFactor).toInt().coerceAtLeast(size.width)
-    val scaledH = (height * scaleFactor).toInt().coerceAtLeast(size.height)
-    val scaled =
-        if (scaledW == width && scaledH == height) this
-        else Bitmap.createScaledBitmap(this, scaledW, scaledH, true)
+    val srcW = (size.width / scaleFactor).toInt().coerceAtMost(width)
+    val srcH = (size.height / scaleFactor).toInt().coerceAtMost(height)
+    val srcX = ((width - srcW) / 2).coerceAtLeast(0)
+    val srcY = ((height - srcH) / 2).coerceAtLeast(0)
 
-    val xOffset = ((scaled.width - size.width) / 2).coerceAtLeast(0)
-    val yOffset = ((scaled.height - size.height) / 2).coerceAtLeast(0)
-    val cropW = size.width.coerceAtMost(scaled.width)
-    val cropH = size.height.coerceAtMost(scaled.height)
-    return Bitmap.createBitmap(scaled, xOffset, yOffset, cropW, cropH)
+    val matrix = Matrix().apply { postScale(scaleFactor, scaleFactor) }
+    return Bitmap.createBitmap(this, srcX, srcY, srcW, srcH, matrix, true)
 }
 
 fun Bitmap.rotateByExif(exif: ExifInterface): Bitmap {
@@ -53,3 +53,26 @@ fun Bitmap.rotateByExif(exif: ExifInterface): Bitmap {
     return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
 }
 
+fun ContentResolver.downSampling(uri: Uri, maxBound: Int): Bitmap {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+
+    var sample = 1
+    val marginRatio = 2
+    val largest = maxOf(bounds.outWidth, bounds.outHeight)
+    while (largest / sample > maxBound * marginRatio) sample *= marginRatio
+
+    val opts = BitmapFactory.Options().apply {
+        inSampleSize = sample
+        inPreferredConfig = Bitmap.Config.RGB_565
+    }
+    return openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
+        ?: error("이미지 로드 실패: $uri")
+}
+
+fun ContentResolver.exif(
+    uri: Uri
+): ExifInterface {
+    return openInputStream(uri)?.use { ExifInterface(it) }
+        ?: error("exif 로드 실패: $uri")
+}

--- a/data/src/main/java/com/wheretogo/data/model/confg/ImageConfig.kt
+++ b/data/src/main/java/com/wheretogo/data/model/confg/ImageConfig.kt
@@ -4,5 +4,6 @@ import com.wheretogo.data.ImageFormat
 
 data class ImageConfig(
     val format: ImageFormat,
-    val maxDownMB: Int
+    val maxDownMB: Int,
+    val maxBitmapStreamCount: Int
 )

--- a/data/src/main/java/com/wheretogo/data/model/gallery/EncodedImage.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/EncodedImage.kt
@@ -1,0 +1,7 @@
+package com.wheretogo.data.model.gallery
+
+import com.wheretogo.domain.ImageSize
+
+data class EncodedImage(
+    val images: Map<ImageSize, ByteArray>,
+)

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -52,7 +52,7 @@ class ImageRepositoryImpl @Inject constructor(
                     .getOrThrow()
 
             val imagePaths = coroutineScope {
-                resizedImages.map { (size, bytes) ->
+                resizedImages.images.map { (size, bytes) ->
                     async { uploadAndSaveImage(imageId, size, bytes) }
                 }.awaitAll()
             }


### PR DESCRIPTION
### 1. 이미지 동시 변환시 메모리 부족 오류 수정

## ✅ 테스트 항목
- [x] 에뮬레이터 저사양 기기에서 여러 사진 동시 변환시 메모리 오류 나지 않는지 확인