### PR TITLE
포토뷰어 스탬프 기능 및 갤러리 그룹화(코스별) 추가

### DIFF
--- a/app-admin/src/main/java/com/dhkim139/admin/wheretogo/feature/report/ReportDetailViewModel.kt
+++ b/app-admin/src/main/java/com/dhkim139/admin/wheretogo/feature/report/ReportDetailViewModel.kt
@@ -82,6 +82,8 @@ class ReportDetailViewModel @Inject constructor(
 
                 ContentType.CHECKPOINT.name -> {
                     checkpointRepository.getCheckPoint(contentId, true).mapSuccess { content ->
+                        if(content==null)
+                            return@launch
                         imageRepository.getImage(content.imageId, ImageSize.SMALL).map { imgUrl ->
                             content.copy(thumbnail = imgUrl)
                         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,7 @@ dependencies {
 
     // Libraries
     implementation(libs.timber)
+    implementation(libs.coil.compose)
 
     // Android Test
     androidTestImplementation(libs.dagger.hilt.android.testing)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <queries>
         <package android:name="com.skt.skaf.l001mtm091"/>
         <package android:name="com.skt.tmap.ku"/>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
     </queries>
     <application
         android:name=".BaseApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <queries>

--- a/app/src/main/java/com/dhkim139/wheretogo/BaseApplication.kt
+++ b/app/src/main/java/com/dhkim139/wheretogo/BaseApplication.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.os.StrictMode
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import com.dhkim139.wheretogo.migration.AppMigration
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
@@ -21,7 +23,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltAndroidApp
-class BaseApplication : Application(), Configuration.Provider {
+class BaseApplication : Application(), Configuration.Provider, ImageLoaderFactory {
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
@@ -31,6 +33,11 @@ class BaseApplication : Application(), Configuration.Provider {
 
     @Inject
     lateinit var appMigration: AppMigration
+
+    @Inject
+    lateinit var imageLoader: ImageLoader
+
+    override fun newImageLoader(): ImageLoader = imageLoader
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -66,4 +66,5 @@ dependencies {
     implementation(libs.google.identity.googleid)
     implementation(libs.sulky.ulid)
     implementation(libs.timber)
+    implementation(libs.coil.compose)
 }

--- a/data/src/main/java/com/wheretogo/data/DataMapper.kt
+++ b/data/src/main/java/com/wheretogo/data/DataMapper.kt
@@ -1,11 +1,19 @@
 package com.wheretogo.data
 
 import com.wheretogo.data.model.auth.DataSyncToken
+import com.wheretogo.data.model.checkpoint.CheckPointCreateContent
 import com.wheretogo.data.model.checkpoint.LocalCheckPoint
 import com.wheretogo.data.model.checkpoint.RemoteCheckPoint
+import com.wheretogo.data.model.comment.CommentCreateContent
 import com.wheretogo.data.model.comment.RemoteComment
+import com.wheretogo.data.model.course.CourseCreateContent
 import com.wheretogo.data.model.course.LocalCourse
 import com.wheretogo.data.model.course.RemoteCourse
+import com.wheretogo.data.model.gallery.ExifEntity
+import com.wheretogo.data.model.gallery.ExifResponse
+import com.wheretogo.data.model.gallery.ImageMetaCreateContent
+import com.wheretogo.data.model.gallery.ImageMetaResponse
+import com.wheretogo.data.model.gallery.PhotoEntity
 import com.wheretogo.data.model.history.LocalHistory
 import com.wheretogo.data.model.history.LocalHistoryGroupWrapper
 import com.wheretogo.data.model.history.LocalHistoryIdGroup
@@ -26,13 +34,12 @@ import com.wheretogo.domain.model.address.LatLng
 import com.wheretogo.domain.model.auth.SyncToken
 import com.wheretogo.domain.model.checkpoint.CheckPoint
 import com.wheretogo.domain.model.checkpoint.CheckPointAddRequest
-import com.wheretogo.data.model.checkpoint.CheckPointCreateContent
-import com.wheretogo.data.model.comment.CommentCreateContent
-import com.wheretogo.data.model.course.CourseCreateContent
 import com.wheretogo.domain.model.comment.Comment
 import com.wheretogo.domain.model.comment.CommentAddRequest
 import com.wheretogo.domain.model.course.Course
 import com.wheretogo.domain.model.course.CourseAddRequest
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.gallery.PhotoExif
 import com.wheretogo.domain.model.history.HistoryGroupWrapper
 import com.wheretogo.domain.model.history.HistoryIdGroup
 import com.wheretogo.domain.model.report.Report
@@ -44,7 +51,9 @@ import com.wheretogo.domain.model.route.Route
 import com.wheretogo.domain.model.user.History
 import com.wheretogo.domain.model.user.Profile
 import com.wheretogo.domain.model.user.ProfilePrivate
+import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.toGeoHash
+import timber.log.Timber
 
 fun RemoteSyncUser.toProfileHistoryPair(): Pair<Profile, History> {
     val profile = publicUser.toProfile(privateUser)
@@ -602,3 +611,78 @@ fun SyncToken.toDataSyncToken(): DataSyncToken {
         msgToken = msgToken
     )
 }
+
+fun PhotoEntity.toGalleryPhoto(): GalleryPhoto? {
+    val (lat, lng) = listOf(exif?.latitude, exif?.longitude)
+    if (thumbnail == null) {
+        Timber.e("$id not found $thumbnail")
+        return null
+    }
+    return GalleryPhoto(
+        id = id,
+        exif = PhotoExif(
+            dateTaken = exif?.timestampMillis,
+            width = exif?.imageWidth,
+            height = exif?.imageHeight,
+            location = if (lat != null && lng != null)
+                LatLng(lat, lng) else null,
+        ),
+        sha256 = sha256,
+        entityId = id,
+        imageId = imageId,
+        courseId = courseId,
+        courseName = courseName,
+        address = address,
+        imageSource = uriString,
+        thumbnail = thumbnail
+    )
+}
+
+fun ImageMetaResponse.toPhotoEntity(): PhotoEntity = PhotoEntity(
+    imageId = imageId,
+    sha256 = sha256,
+    exif = exif.toEntity(),
+    address = address,
+)
+
+fun PhotoEntity.toCreateContent(): ImageMetaCreateContent = ImageMetaCreateContent(
+    imageId = imageId,
+    exif = exif?.toDomain() ?: ExifData(),
+    address = address ?: "",
+    sha256 = sha256,
+    createAt = System.currentTimeMillis()
+)
+
+fun ExifResponse.toEntity(): ExifEntity = ExifEntity(
+    latitude = latitude,
+    longitude = longitude,
+    altitude = altitude,
+    dateTimeOriginal = dateTimeOriginal,
+    timestampMillis = timestampMillis,
+    make = make,
+    model = model,
+    orientation = orientation,
+    imageWidth = imageWidth,
+    imageHeight = imageHeight,
+    fNumber = fNumber,
+    exposureTime = exposureTime,
+    iso = iso,
+    focalLength = focalLength,
+)
+
+fun ExifEntity.toDomain(): ExifData = ExifData(
+    latitude = latitude,
+    longitude = longitude,
+    altitude = altitude,
+    dateTimeOriginal = dateTimeOriginal,
+    timestampMillis = timestampMillis,
+    make = make,
+    model = model,
+    orientation = orientation,
+    imageWidth = imageWidth,
+    imageHeight = imageHeight,
+    fNumber = fNumber,
+    exposureTime = exposureTime,
+    iso = iso,
+    focalLength = focalLength,
+)

--- a/data/src/main/java/com/wheretogo/data/DataPolicy.kt
+++ b/data/src/main/java/com/wheretogo/data/DataPolicy.kt
@@ -204,6 +204,7 @@ enum class FireStoreCollections {
     CHECKPOINT,
     ROUTE,
     LIKE,
+    IMAGE,
 
     COMMENT,
     REPORT,

--- a/data/src/main/java/com/wheretogo/data/datasource/CheckPointRemoteDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/CheckPointRemoteDatasource.kt
@@ -15,6 +15,6 @@ interface CheckPointRemoteDatasource {
 
     suspend fun updateCheckPoint(checkPointId: String, caption: String): Result<Unit>
 
-    suspend fun removeCheckPoint(checkPointId: String): Result<Unit>
+    suspend fun removeCheckPoint(checkPointId: String, courseId: String): Result<Unit>
 
 }

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -1,11 +1,12 @@
 package com.wheretogo.data.datasource
 
 import com.wheretogo.data.model.gallery.EncodedImage
+import com.wheretogo.data.model.gallery.ExifEntity
+import com.wheretogo.data.model.gallery.PhotoEntity
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.MediaImage
-import com.wheretogo.domain.model.gallery.GalleryPhoto
+import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 
@@ -19,23 +20,31 @@ interface ImageLocalDatasource {
 
     suspend fun getDefaultImageBytes(size: ImageSize): Result<ByteArray>
 
-    suspend fun openAndResizeImage(
+    suspend fun encodeImage(
         sourceUriString: String,
         sizeGroup: List<ImageSize>,
         compressionQuality: Int = 80
     ): Result<EncodedImage>
 
-    suspend fun getExif(imageUriString: String): Result<ExifData>
+    suspend fun getExif(imageUriString: String): Result<ExifEntity>
 
     suspend fun getPreview(imageUriString: String): Result<FilePreview>
 
     suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
 
-    suspend fun loadGalleyPhotos():Result<List<GalleryPhoto>>
+    suspend fun loadAllPhotos(): Result<List<PhotoEntity>>
 
-    suspend fun saveGalleryPhotos(uriStrings:List<String>): Result<List<Long>>
+    fun observePhotos(): Flow<List<PhotoEntity>>
 
-    suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit>
+    suspend fun getPhotosByHash(hashes:List<String>): Result<List<PhotoEntity>>
+
+    suspend fun getPhotosByImageId(imageIds: List<String>): Result<List<PhotoEntity>>
+
+    suspend fun saveGalleryPhotos(uriStrings: List<String>): Result<List<Long>>
+
+    suspend fun upsertPhotos(photos: List<PhotoEntity>): Result<List<Long>>
+
+    suspend fun updatePhotos(photos: List<PhotoEntity>): Result<Unit>
 
     suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>
 }

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageLocalDatasource.kt
@@ -35,5 +35,7 @@ interface ImageLocalDatasource {
 
     suspend fun saveGalleryPhotos(uriStrings:List<String>): Result<List<Long>>
 
+    suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit>
+
     suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>
 }

--- a/data/src/main/java/com/wheretogo/data/datasource/ImageRemoteDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/ImageRemoteDatasource.kt
@@ -1,12 +1,27 @@
 package com.wheretogo.data.datasource
 
+import com.wheretogo.data.model.gallery.ImageMetaCreateContent
+import com.wheretogo.data.model.gallery.ImageMetaResponse
 import com.wheretogo.domain.ImageSize
+import java.io.File
 
 
 interface ImageRemoteDatasource {
 
-    suspend fun uploadImage(
+    suspend fun getImageMetasByUserId(userId: String): Result<List<ImageMetaResponse>>
+
+    suspend fun setImageMetas(metas: List<ImageMetaCreateContent>): Result<List<String>>
+
+    suspend fun removeImageMetas(metas: List<String>): Result<List<String>>
+
+    suspend fun uploadImageByByteArray(
         imageByteArray: ByteArray,
+        imageId: String,
+        size: ImageSize
+    ): Result<Unit>
+
+    suspend fun uploadImageByFile(
+        imageFile: File,
         imageId: String,
         size: ImageSize
     ): Result<Unit>

--- a/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
+++ b/data/src/main/java/com/wheretogo/data/datasource/UserLocalDatasource.kt
@@ -14,6 +14,8 @@ interface UserLocalDatasource {
 
     suspend fun getHistory(type: DataHistoryType): LocalHistoryGroupWrapper
 
+    fun observeHistory(type: DataHistoryType): Flow<LocalHistoryGroupWrapper>
+
     suspend fun setProfile(profile: LocalProfile): Result<Unit>
 
     suspend fun iniHistory(history: LocalHistory): Result<Unit>

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/CheckPointRemoteDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/CheckPointRemoteDatasourceImpl.kt
@@ -6,7 +6,9 @@ import com.wheretogo.data.DataBuildConfig
 import com.wheretogo.data.FireStoreCollections
 import com.wheretogo.data.datasource.CheckPointRemoteDatasource
 import com.wheretogo.data.datasourceimpl.service.ContentApiService
+import com.wheretogo.data.feature.mapDataError
 import com.wheretogo.data.feature.safeApiCall
+import com.wheretogo.data.feature.safeMsgApiCall
 import com.wheretogo.data.model.checkpoint.RemoteCheckPoint
 import com.wheretogo.data.model.checkpoint.CheckPointCreateContent
 import kotlinx.coroutines.tasks.await
@@ -19,7 +21,7 @@ class CheckPointRemoteDatasourceImpl @Inject constructor(
     private val firestore by lazy { FirebaseFirestore.getInstance() }
     private val checkPointRootCollection =
         buildConfig.dbPrefix + FireStoreCollections.CHECKPOINT.name
-
+    private val type = "CHECKPOINT"
     override suspend fun getCheckPointGroup(checkPointIdGroup: List<String>): Result<List<RemoteCheckPoint>> {
         return runCatching {
             checkPointIdGroup.chunked(30).flatMap { chunk ->
@@ -68,11 +70,9 @@ class CheckPointRemoteDatasourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun removeCheckPoint(checkPointId: String): Result<Unit> {
-        return runCatching {
-            firestore.collection(checkPointRootCollection).document(checkPointId)
-                .delete()
-                .await()
-        }
+    override suspend fun removeCheckPoint(checkPointId: String, courseId: String): Result<Unit> {
+        return safeMsgApiCall {
+            contentApiService.removeCheckPoint(checkPointId, type, courseId)
+        }.map {}.mapDataError()
     }
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -5,6 +5,7 @@ import android.content.ContentUris
 import android.content.Context
 import android.database.Cursor
 import android.graphics.Bitmap
+import android.location.Geocoder
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -40,6 +41,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.Locale
 import javax.inject.Inject
 
 class ImageLocalDatasourceImpl @Inject constructor(
@@ -129,7 +131,7 @@ class ImageLocalDatasourceImpl @Inject constructor(
         val maxBound = sizeGroup.maxOf { maxOf(it.width, it.height) }
         val decoded = resolver.downSampling(uri, maxBound)
         val rotated = decoded.rotateByExif(exif)
-        
+
         if(rotated != decoded) decoded.recycle()
 
         val images = sizeGroup.associateWith { size ->
@@ -253,27 +255,40 @@ class ImageLocalDatasourceImpl @Inject constructor(
     private suspend fun createEntity(targets: Map<String, String>): List<PhotoEntity> {
         val semaphore = Semaphore(10)
         return coroutineScope {
+            val geocoder = Geocoder(context, Locale.KOREA)
             targets.map { (sourceKey, uriString) ->
                 async {
                     semaphore.withPermit {
                         runCatching {
                             val imageId = generateImageId()
                             val exif = context.contentResolver.createExifData(uriString)
-                            val file = openAndResizeImage(uriString, ImageSize.entries)
-                                .getOrThrow()
-                                .images
-                                .saveImages(imageId)
+                            val (lat, lng) = exif?.latitude to exif?.longitude
+
+                            val fileDeferred = async {
+                                openAndResizeImage(uriString, ImageSize.entries)
+                                    .getOrThrow()
+                                    .images
+                                    .saveImages(imageId)
+                            }
+
+                            val addressDeferred = async {
+                                if (lat != null && lng != null) {
+                                    geocoder.getFromLocation(lat, lng, 1)?.firstOrNull()
+                                } else null
+                            }
+
 
                             PhotoEntity(
                                 id = generateId(),
                                 imageId = imageId,
-                                fileName = file.name,
+                                fileName = fileDeferred.await().name,
                                 sourceKey = sourceKey,
                                 dateTaken = exif?.timestampMillis,
                                 width = exif?.imageWidth,
                                 height = exif?.imageHeight,
-                                latitude = exif?.latitude,
-                                longitude = exif?.longitude,
+                                latitude = lat,
+                                longitude = lng,
+                                address = addressDeferred.await()?.getAddressLine(0)
                             )
                         }.getOrNull()
                     }
@@ -299,7 +314,8 @@ class ImageLocalDatasourceImpl @Inject constructor(
                     LatLng(latitude, longitude) else null,
             ),
             courseId = courseId,
-            courseName = courseName
+            courseName = courseName,
+            address = address
         )
     }
 

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -224,6 +224,12 @@ class ImageLocalDatasourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit> {
+        return runCatching {
+            photoDao.updateGalleryPhotos(photos)
+        }
+    }
+
     override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
         return runCatching {
             val removed= buildSet {
@@ -292,6 +298,8 @@ class ImageLocalDatasourceImpl @Inject constructor(
                 location = if (latitude != null && longitude != null)
                     LatLng(latitude, longitude) else null,
             ),
+            courseId = courseId,
+            courseName = courseName
         )
     }
 

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageLocalDatasourceImpl.kt
@@ -22,14 +22,12 @@ import com.wheretogo.data.feature.exif
 import com.wheretogo.data.feature.rotateByExif
 import com.wheretogo.data.feature.scaleCropToFill
 import com.wheretogo.data.feature.scaleToFitInside
+import com.wheretogo.data.feature.sha256
 import com.wheretogo.data.model.confg.ImageConfig
 import com.wheretogo.data.model.gallery.EncodedImage
+import com.wheretogo.data.model.gallery.ExifEntity
 import com.wheretogo.data.model.gallery.PhotoEntity
 import com.wheretogo.domain.ImageSize
-import com.wheretogo.domain.model.address.LatLng
-import com.wheretogo.domain.model.gallery.GalleryPhoto
-import com.wheretogo.domain.model.gallery.PhotoExif
-import com.wheretogo.domain.model.util.ExifData
 import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.MediaImage
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -37,6 +35,7 @@ import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import java.io.ByteArrayOutputStream
@@ -55,11 +54,15 @@ class ImageLocalDatasourceImpl @Inject constructor(
     private val ext = imageConfig.format.ext
     private val mediaUri: Uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 
+    private fun generateImageId():String = "IM${ULID().nextULID()}"
+    private fun generatePath(imageId: String, size: ImageSize): String =
+        "image/${size.pathName}/$imageId.${imageConfig.format.ext}"
+
     override suspend fun getImage(imageId: String, size: ImageSize): File {
         val localFile =
             File(
                 imageFile.parentFile,
-                "image/${size.pathName}/${imageId}.$ext"
+                generatePath(imageId,size)
             ).apply {
                 if (!parentFile!!.exists()) {
                     parentFile?.mkdirs()
@@ -119,7 +122,7 @@ class ImageLocalDatasourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun openAndResizeImage(
+    override suspend fun encodeImage(
         sourceUriString: String,
         sizeGroup: List<ImageSize>,
         compressionQuality: Int,
@@ -127,6 +130,7 @@ class ImageLocalDatasourceImpl @Inject constructor(
         val uri = sourceUriString.toUri()
         val resolver = context.contentResolver
         val exif = resolver.exif(uri)
+        val sha256 = resolver.sha256(uri)
 
         val maxBound = sizeGroup.maxOf { maxOf(it.width, it.height) }
         val decoded = resolver.downSampling(uri, maxBound)
@@ -152,10 +156,10 @@ class ImageLocalDatasourceImpl @Inject constructor(
 
         rotated.recycle()
 
-        EncodedImage(images = images)
+        EncodedImage(images = images, sha256 = sha256)
     }
 
-    override suspend fun getExif(imageUriString: String): Result<ExifData> {
+    override suspend fun getExif(imageUriString: String): Result<ExifEntity> {
         return runCatching {
             context.contentResolver.openInputStream(imageUriString.toUri())?.use { stream ->
                 exifReader.read(stream)
@@ -190,11 +194,12 @@ class ImageLocalDatasourceImpl @Inject constructor(
 
     override suspend fun saveGalleryPhotos(uriStrings: List<String>): Result<List<Long>> = runCatching {
         val keyed = uriStrings.associateBy { buildExistingKey(it) }
-        val existing = photoDao.findExistingKeys(keyed.keys.toList()).toSet()
-        val targets = keyed.filterKeys { it !in existing }
+        val existingKeys = photoDao.findExistingKeys(keyed.keys.toList()).toSet()
+        val targets = keyed.filterKeys { it !in existingKeys }
         if (targets.isEmpty()) return@runCatching emptyList()
+
         val entities = createEntity(targets)
-        val rowIds = photoDao.insertAll(entities)
+        val rowIds = upsertPhotos(entities).getOrThrow()
 
         entities.filterIndexed { i, entity ->
             val inserted = rowIds.getOrNull(i) != -1L
@@ -205,37 +210,71 @@ class ImageLocalDatasourceImpl @Inject constructor(
         }.map { it.id }
     }
 
-    override suspend fun loadGalleyPhotos(): Result<List<GalleryPhoto>> {
+    override suspend fun upsertPhotos(photos: List<PhotoEntity>): Result<List<Long>> {
         return runCatching {
-            photoDao.getAll().mapNotNull {
-                it.toGalleryPhoto(it.imageId)
+            val local = loadAllPhotos().getOrThrow()
+            val update = mutableListOf<PhotoEntity>()
+            val insert = mutableListOf<PhotoEntity>()
+            photos.forEach { r->
+                val l = local.firstOrNull{it.sha256 == r.sha256}
+                if(l == null)
+                    insert.add(r)
+                else {
+                    update.add(
+                        l.copy(
+                            imageId = r.imageId,
+                            courseId = r.courseId,
+                            courseName = r.courseName,
+                            sourceKey = r.sourceKey,
+                            uriString = r.uriString,
+                        )
+                    )
+                }
             }
+            photoDao.updatePhotos(update) +
+            photoDao.insertAll(insert)
         }
     }
 
-    private fun ContentResolver.createExifData(uriString: String): ExifData?{
+    override suspend fun loadAllPhotos(): Result<List<PhotoEntity>> {
+        return runCatching { photoDao.getAll() }
+    }
+
+    override fun observePhotos(): Flow<List<PhotoEntity>> {
+        return photoDao.observePhotos()
+    }
+
+    override suspend fun getPhotosByHash(hashes:List<String>): Result<List<PhotoEntity>> {
+        return runCatching { photoDao.getByHashes(hashes) }
+    }
+
+    override suspend fun getPhotosByImageId(imageIds:List<String>): Result<List<PhotoEntity>> {
+        return runCatching { photoDao.getByImageId(imageIds.toSet()) }
+    }
+
+    private fun ContentResolver.createExifData(uriString: String): ExifEntity?{
         val uri = uriString.toUri()
         return openInputStream(uri)?.use { exifReader.read(it) }
     }
 
-    suspend fun Map<ImageSize, ByteArray>.saveImages(imageId: String) : File {
-        return  coroutineScope {
-            map { (size, bytes) ->
+    suspend fun Map<ImageSize, ByteArray>.saveImages(imageId: String): Map<ImageSize, File> {
+        return coroutineScope {
+            mapValues { (size, bytes) ->
                 async { saveImage(bytes, imageId, size).getOrThrow() }
-            }.awaitAll().first()
+            }.mapValues { it.value.await() }
         }
     }
 
-    override suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit> {
+    override suspend fun updatePhotos(photos: List<PhotoEntity>): Result<Unit> {
         return runCatching {
-            photoDao.updateGalleryPhotos(photos)
+            photoDao.updatePhotos(photos)
         }
     }
 
     override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
         return runCatching {
             val removed= buildSet {
-                val photos= photoDao.getByIds(ids)
+                val photos= photoDao.getById(ids)
                 coroutineScope {
                     photos.map { entity ->
                         async {
@@ -260,15 +299,13 @@ class ImageLocalDatasourceImpl @Inject constructor(
                 async {
                     semaphore.withPermit {
                         runCatching {
-                            val imageId = generateImageId()
                             val exif = context.contentResolver.createExifData(uriString)
                             val (lat, lng) = exif?.latitude to exif?.longitude
 
-                            val fileDeferred = async {
-                                openAndResizeImage(uriString, ImageSize.entries)
+                            val imageId = generateImageId()
+                            val encodeDeferred = async {
+                                encodeImage(uriString, ImageSize.entries)
                                     .getOrThrow()
-                                    .images
-                                    .saveImages(imageId)
                             }
 
                             val addressDeferred = async {
@@ -277,18 +314,19 @@ class ImageLocalDatasourceImpl @Inject constructor(
                                 } else null
                             }
 
+                            val encodedImages = encodeDeferred.await()
+
+                            val images = encodedImages.images
+                                .saveImages(imageId)
 
                             PhotoEntity(
-                                id = generateId(),
                                 imageId = imageId,
-                                fileName = fileDeferred.await().name,
                                 sourceKey = sourceKey,
-                                dateTaken = exif?.timestampMillis,
-                                width = exif?.imageWidth,
-                                height = exif?.imageHeight,
-                                latitude = lat,
-                                longitude = lng,
-                                address = addressDeferred.await()?.getAddressLine(0)
+                                sha256 = encodedImages.sha256,
+                                exif = exif,
+                                address = addressDeferred.await()?.getAddressLine(0),
+                                thumbnail = images[ImageSize.SMALL]!!.toUri().toString(),
+                                uriString = images[ImageSize.NORMAL]!!.toUri().toString()
                             )
                         }.getOrNull()
                     }
@@ -296,29 +334,6 @@ class ImageLocalDatasourceImpl @Inject constructor(
             }.awaitAll().filterNotNull()
         }
     }
-
-    private suspend fun PhotoEntity.toGalleryPhoto(imageId:String): GalleryPhoto? {
-        val uriString= getImage(imageId, ImageSize.NORMAL).toUri().path?:return null
-        val thumbnail= getImage(imageId, ImageSize.SMALL).toUri().path?:return null
-
-        return GalleryPhoto(
-            id = id,
-            imageId = imageId,
-            uriString = uriString,
-            thumbnail= thumbnail,
-            exif = PhotoExif(
-                dateTaken = dateTaken,
-                width = width,
-                height = height,
-                location = if (latitude != null && longitude != null)
-                    LatLng(latitude, longitude) else null,
-            ),
-            courseId = courseId,
-            courseName = courseName,
-            address = address
-        )
-    }
-
 
     private fun ContentResolver.query(offset: Int, limit: Int): Cursor? {
         val projection = arrayOf(MediaStore.Images.Media._ID)
@@ -374,13 +389,4 @@ class ImageLocalDatasourceImpl @Inject constructor(
 
     private fun buildExistingKey(uriString: String): String =
         uriString.toUri().lastPathSegment ?: uriString.toUri().toString()
-
-    private var lastId = 0L
-    private fun generateId(): Long {
-        val now = System.currentTimeMillis()
-        lastId = if (now <= lastId) lastId + 1 else now
-        return lastId
-    }
-
-    private fun generateImageId():String = "IM${ULID().nextULID()}"
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageRemoteDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/ImageRemoteDatasourceImpl.kt
@@ -1,13 +1,25 @@
 package com.wheretogo.data.datasourceimpl
 
 
+import androidx.core.net.toUri
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
+import com.wheretogo.data.FireStoreCollections
 import com.wheretogo.data.datasource.ImageRemoteDatasource
 import com.wheretogo.data.model.confg.ImageConfig
+import com.wheretogo.data.model.gallery.ImageMetaCreateContent
+import com.wheretogo.data.model.gallery.ImageMetaResponse
 import com.wheretogo.domain.ImageSize
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.tasks.await
+import timber.log.Timber
+import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -15,16 +27,77 @@ import kotlin.coroutines.resumeWithException
 class ImageRemoteDatasourceImpl @Inject constructor(
     private val imageConfig: ImageConfig
 ) : ImageRemoteDatasource {
-    private val firebaseStorage by lazy { FirebaseStorage.getInstance() }
+    private val storage by lazy { FirebaseStorage.getInstance() }
+    private val store by lazy { FirebaseFirestore.getInstance() }
+    private val rootCollection = FireStoreCollections.IMAGE.name
     private val ext = imageConfig.format.ext
-    override suspend fun uploadImage(
+    private val maxConcurrency = 20
+
+    override suspend fun getImageMetasByUserId(userId: String): Result<List<ImageMetaResponse>> {
+        return runCatching {
+            store.collection(rootCollection)
+                .whereEqualTo(ImageMetaResponse::userId.name, userId)
+                .get()
+                .await()
+                .documents
+                .mapNotNull { it.toObject(ImageMetaResponse::class.java) }
+        }
+    }
+
+    override suspend fun setImageMetas(metas: List<ImageMetaCreateContent>): Result<List<String>> =
+        runCatching {
+            coroutineScope {
+                val semaphore = Semaphore(maxConcurrency)
+                metas.map { meta ->
+                    async {
+                        semaphore.withPermit {
+                            try {
+                                store.collection(rootCollection)
+                                    .document(meta.imageId)
+                                    .set(meta)
+                                    .await()
+                                null
+                            } catch (e: Exception) {
+                                Timber.e(e.stackTraceToString())
+                                meta.imageId
+                            }
+                        }
+                    }
+                }.awaitAll().filterNotNull()
+            }
+        }
+
+    override suspend fun removeImageMetas(metas: List<String>): Result<List<String>> = runCatching {
+        coroutineScope {
+            val semaphore = Semaphore(maxConcurrency)
+            metas.map { metaId ->
+                async {
+                    semaphore.withPermit {
+                        try {
+                            store.collection(rootCollection)
+                                .document(metaId)
+                                .delete()
+                                .await()
+                            null
+                        } catch (e: Exception) {
+                            Timber.e(e.stackTraceToString())
+                            metaId
+                        }
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+    }
+
+
+    override suspend fun uploadImageByByteArray(
         imageByteArray: ByteArray,
         imageId: String,
         size: ImageSize
     ): Result<Unit> {
         return runCatching {
             val storageRef: StorageReference =
-                firebaseStorage.reference.child("image/${size.pathName}/$imageId.$ext")
+                storage.reference.child("image/${size.pathName}/$imageId.$ext")
             suspendCancellableCoroutine { con ->
                 storageRef.putBytes(imageByteArray)
                     .addOnSuccessListener {
@@ -37,10 +110,22 @@ class ImageRemoteDatasourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun uploadImageByFile(
+        imageFile: File,
+        imageId: String,
+        size: ImageSize
+    ): Result<Unit> {
+        return runCatching {
+            val storageRef: StorageReference =
+                storage.reference.child("image/${size.pathName}/$imageId.$ext")
+            storageRef.putFile(imageFile.toUri()).await()
+        }
+    }
+
     override suspend fun downloadImage(filename: String, size: ImageSize): Result<ByteArray> {
         return runCatching {
             val storageRef: StorageReference =
-                firebaseStorage.reference.child("image/${size.pathName}/$filename.$ext")
+                storage.reference.child("image/${size.pathName}/$filename.$ext")
             suspendCancellableCoroutine { con ->
                 storageRef.getBytes(imageConfig.maxDownMB.toLong() * 1024 * 1024)
                     .addOnSuccessListener { byteArray ->
@@ -55,7 +140,7 @@ class ImageRemoteDatasourceImpl @Inject constructor(
     override suspend fun removeImage(filename: String, size: ImageSize): Result<Unit> {
         return runCatching {
             val storageRef =
-                firebaseStorage.reference.child("image/${size.pathName}/$filename.$ext")
+                storage.reference.child("image/${size.pathName}/$filename.$ext")
             storageRef.delete().await()
             Unit
         }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/UserLocalDatasourceImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/UserLocalDatasourceImpl.kt
@@ -16,6 +16,7 @@ import com.wheretogo.data.model.history.LocalHistoryIdGroup
 import com.wheretogo.data.model.user.LocalProfile
 import com.wheretogo.data.model.user.LocalProfilePrivate
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -141,7 +142,8 @@ class UserLocalDatasourceImpl @Inject constructor(
             preferences[historyKey]?.run { Cbor.decodeFromByteArray(this) } ?: LocalHistoryIdGroup()
         }.first()
 
-        val addedAt = if (addedAtKey == null) 0L else userDataStore.data.map { preferences ->
+        val addedAt = userDataStore.data.map { preferences ->
+            if (addedAtKey == null) return@map 0L
             preferences[addedAtKey] ?: 0L
         }.first()
 
@@ -150,6 +152,27 @@ class UserLocalDatasourceImpl @Inject constructor(
             historyIdGroup = historyIdGroup,
             lastAddedAt = addedAt
         )
+    }
+
+    override fun observeHistory(type: DataHistoryType): Flow<LocalHistoryGroupWrapper> {
+        val historyKey = getHistoryKey(type)
+        val addedAtKey = getHistoryAddedAtKey(type)
+        val historyIdGroup = userDataStore.data.map { preferences ->
+            preferences[historyKey]?.run { Cbor.decodeFromByteArray(this) } ?: LocalHistoryIdGroup()
+        }
+
+        val addedAt = userDataStore.data.map { preferences ->
+            if (addedAtKey == null) return@map 0L
+            preferences[addedAtKey] ?: 0L
+        }
+
+        return historyIdGroup.combine(addedAt){ idGroup, addedAt->
+            LocalHistoryGroupWrapper(
+                type = type,
+                historyIdGroup = idGroup,
+                lastAddedAt = addedAt
+            )
+        }
     }
 
     override suspend fun setProfile(profile: LocalProfile): Result<Unit> {

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
@@ -6,8 +6,9 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.RoomDatabase
+import androidx.room.Transaction
 import com.wheretogo.data.model.gallery.PhotoEntity
-import kotlinx.coroutines.flow.Flow
+import com.wheretogo.domain.model.gallery.GalleryPhoto
 
 @Database(entities = [PhotoEntity::class], version = 1, exportSchema = false)
 abstract class GalleryDatabase : RoomDatabase() {
@@ -22,7 +23,7 @@ interface GalleryPhotoDao {
     suspend fun insertAll(photos: List<PhotoEntity>): List<Long>
 
     @Query(
-        """
+"""
         SELECT * FROM gallery_photo
         ORDER BY (dateTaken IS NULL), dateTaken DESC
         """
@@ -38,12 +39,43 @@ interface GalleryPhotoDao {
     @Query("DELETE FROM gallery_photo WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: Set<Long>)
 
-    // 흐름 관찰이 필요하면 추가 (확장용)
     @Query(
-        """
-        SELECT * FROM gallery_photo
-        ORDER BY (dateTaken IS NULL), dateTaken DESC
+"""
+        UPDATE gallery_photo 
+        SET dateTaken = COALESCE(:dateTaken, dateTaken),
+            width = COALESCE(:width, width),
+            height = COALESCE(:height, height),
+            latitude = COALESCE(:latitude, latitude),
+            longitude = COALESCE(:longitude, longitude),
+            courseId = COALESCE(:courseId, longitude),
+            courseName = COALESCE(:courseName, longitude)
+        WHERE id = :id
         """
     )
-    fun observeAll(): Flow<List<PhotoEntity>>
+    suspend fun updateById(
+        id: Long,
+        dateTaken: Long? = null,
+        width: Int? = null,
+        height: Int? = null,
+        latitude: Double? = null,
+        longitude: Double? = null,
+        courseId: String? = null,
+        courseName: String? = null
+    )
+
+    @Transaction
+    suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>) {
+        photos.forEach { photo ->
+            updateById(
+                id = photo.id,
+                dateTaken = photo.exif.dateTaken,
+                width = photo.exif.width,
+                height = photo.exif.width,
+                latitude = photo.exif.location?.latitude,
+                longitude = photo.exif.location?.longitude,
+                courseId = photo.courseId,
+                courseName = photo.courseName
+            )
+        }
+    }
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/database/GalleryDatabase.kt
@@ -8,74 +8,82 @@ import androidx.room.Query
 import androidx.room.RoomDatabase
 import androidx.room.Transaction
 import com.wheretogo.data.model.gallery.PhotoEntity
-import com.wheretogo.domain.model.gallery.GalleryPhoto
+import kotlinx.coroutines.flow.Flow
 
 @Database(entities = [PhotoEntity::class], version = 1, exportSchema = false)
 abstract class GalleryDatabase : RoomDatabase() {
-    abstract fun photoDao(): GalleryPhotoDao
+    abstract fun photoDao(): PhotoDao
 }
 
 
 @Dao
-interface GalleryPhotoDao {
+interface PhotoDao {
 
     @Insert(onConflict = OnConflictStrategy.Companion.IGNORE)
     suspend fun insertAll(photos: List<PhotoEntity>): List<Long>
 
     @Query(
 """
-        SELECT * FROM gallery_photo
-        ORDER BY (dateTaken IS NULL), dateTaken DESC
+        SELECT * FROM photo
+        ORDER BY (timestampMillis IS NULL), timestampMillis DESC
         """
     )
     suspend fun getAll(): List<PhotoEntity>
 
-    @Query("SELECT sourceKey FROM gallery_photo WHERE sourceKey IN (:keys)")
+    @Query(
+        """
+        SELECT * FROM photo
+        ORDER BY (timestampMillis IS NULL), timestampMillis DESC
+        """
+    )
+    fun observePhotos(): Flow<List<PhotoEntity>>
+
+    @Query("SELECT * FROM photo WHERE sha256 IN (:hashes)")
+    suspend fun getByHashes(hashes: List<String>): List<PhotoEntity>
+
+    @Query("SELECT sourceKey FROM photo WHERE sourceKey IN (:keys)")
     suspend fun findExistingKeys(keys: List<String>): List<String>
 
-    @Query("SELECT * FROM gallery_photo WHERE id IN (:ids)")
-    suspend fun getByIds(ids: Set<Long>): List<PhotoEntity>
+    @Query("SELECT * FROM photo WHERE id IN (:ids)")
+    suspend fun getById(ids: Set<Long>): List<PhotoEntity>
 
-    @Query("DELETE FROM gallery_photo WHERE id IN (:ids)")
+    @Query("SELECT * FROM photo WHERE imageId IN (:ids)")
+    suspend fun getByImageId(ids: Set<String>): List<PhotoEntity>
+
+    @Query("DELETE FROM photo WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: Set<Long>)
 
     @Query(
-"""
-        UPDATE gallery_photo 
-        SET dateTaken = COALESCE(:dateTaken, dateTaken),
-            width = COALESCE(:width, width),
-            height = COALESCE(:height, height),
-            latitude = COALESCE(:latitude, latitude),
-            longitude = COALESCE(:longitude, longitude),
-            courseId = COALESCE(:courseId, longitude),
-            courseName = COALESCE(:courseName, longitude)
+        """
+        UPDATE photo 
+        SET imageId = COALESCE(:imageId, imageId),
+            courseId = COALESCE(:courseId, courseId),
+            courseName = COALESCE(:courseName, courseName),
+            uriString = COALESCE(:uriString, uriString),
+            sourceKey = COALESCE(:sourceKey, sourceKey)
         WHERE id = :id
         """
-    )
-    suspend fun updateById(
+    ) suspend fun updateById(
         id: Long,
-        dateTaken: Long? = null,
-        width: Int? = null,
-        height: Int? = null,
-        latitude: Double? = null,
-        longitude: Double? = null,
+        imageId: String? = null,
         courseId: String? = null,
-        courseName: String? = null
+        courseName: String? = null,
+        uriString: String? = null,
+        sourceKey: String? = null,
     )
 
     @Transaction
-    suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>) {
-        photos.forEach { photo ->
+    suspend fun updatePhotos(photos: List<PhotoEntity>) :List<Long> {
+        return photos.map { photo ->
             updateById(
                 id = photo.id,
-                dateTaken = photo.exif.dateTaken,
-                width = photo.exif.width,
-                height = photo.exif.width,
-                latitude = photo.exif.location?.latitude,
-                longitude = photo.exif.location?.longitude,
+                imageId = photo.imageId,
                 courseId = photo.courseId,
-                courseName = photo.courseName
+                courseName = photo.courseName,
+                uriString = photo.uriString,
+                sourceKey = photo.sourceKey,
             )
+            photo.id
         }
     }
 }

--- a/data/src/main/java/com/wheretogo/data/datasourceimpl/service/ContentApiService.kt
+++ b/data/src/main/java/com/wheretogo/data/datasourceimpl/service/ContentApiService.kt
@@ -13,6 +13,7 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface ContentApiService {
@@ -41,5 +42,12 @@ interface ContentApiService {
     suspend fun addCheckPoint(
         @Body body: CheckPointCreateContent
     ): Response<DataResponse<RemoteCheckPoint>>
+
+    @DELETE("api/content/{id}")
+    suspend fun removeCheckPoint(
+        @Path("id") contentId: String,
+        @Query("type") type: String,
+        @Query("groupId") groupId: String,
+    ): Response<MessageResponse>
 
 }

--- a/data/src/main/java/com/wheretogo/data/di/FeatureModule.kt
+++ b/data/src/main/java/com/wheretogo/data/di/FeatureModule.kt
@@ -1,7 +1,11 @@
 package com.wheretogo.data.di
 
 import android.content.Context
+import coil.ImageLoader
 import com.wheretogo.data.feature.DataEncryptorImpl
+import com.wheretogo.data.feature.StoragePathMapper
+import com.wheretogo.data.feature.StorageReferenceFetcher
+import com.wheretogo.data.model.confg.ImageConfig
 import com.wheretogo.domain.feature.DataEncryptor
 import dagger.Module
 import dagger.Provides
@@ -20,4 +24,15 @@ object FeatureModule {
         return DataEncryptorImpl(context)
     }
 
+    @Provides
+    @Singleton
+    fun provideImageLoader(
+        @ApplicationContext context: Context,
+        imageConfig: ImageConfig
+    ): ImageLoader =
+        ImageLoader.Builder(context)
+            .components {
+                add(StoragePathMapper())
+                add(StorageReferenceFetcher.Factory(imageConfig))
+            }.build()
 }

--- a/data/src/main/java/com/wheretogo/data/feature/Bitmap.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/Bitmap.kt
@@ -1,11 +1,7 @@
 package com.wheretogo.data.feature
 
-import android.content.ContentResolver
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Matrix
-import android.net.Uri
-import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import com.wheretogo.domain.ImageSize
 
@@ -51,28 +47,4 @@ fun Bitmap.rotateByExif(exif: ExifInterface): Bitmap {
         else -> return this   // NORMAL/UNDEFINED → 회전 불필요, 원본 반환
     }
     return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
-}
-
-fun ContentResolver.downSampling(uri: Uri, maxBound: Int): Bitmap {
-    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
-
-    var sample = 1
-    val marginRatio = 2
-    val largest = maxOf(bounds.outWidth, bounds.outHeight)
-    while (largest / sample > maxBound * marginRatio) sample *= marginRatio
-
-    val opts = BitmapFactory.Options().apply {
-        inSampleSize = sample
-        inPreferredConfig = Bitmap.Config.RGB_565
-    }
-    return openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
-        ?: error("이미지 로드 실패: $uri")
-}
-
-fun ContentResolver.exif(
-    uri: Uri
-): ExifInterface {
-    return openInputStream(uri)?.use { ExifInterface(it) }
-        ?: error("exif 로드 실패: $uri")
 }

--- a/data/src/main/java/com/wheretogo/data/feature/ContentResolver.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/ContentResolver.kt
@@ -1,0 +1,53 @@
+package com.wheretogo.data.feature
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import java.io.InputStream
+import java.security.MessageDigest
+
+
+fun ContentResolver.downSampling(uri: Uri, maxBound: Int): Bitmap {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+
+    var sample = 1
+    val marginRatio = 2
+    val largest = maxOf(bounds.outWidth, bounds.outHeight)
+    while (largest / sample > maxBound * marginRatio) sample *= marginRatio
+
+    val opts = BitmapFactory.Options().apply {
+        inSampleSize = sample
+        inPreferredConfig = Bitmap.Config.RGB_565
+    }
+    return openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
+        ?: error("이미지 로드 실패: $uri")
+}
+
+fun ContentResolver.exif(
+    uri: Uri
+): ExifInterface {
+    return openInputStream(uri)?.use { ExifInterface(it) }
+        ?: error("exif 로드 실패: $uri")
+}
+
+
+fun ContentResolver.sha256(
+    uri: Uri
+): String {
+    return openInputStream(uri)?.use { it.sha256() }?: error("md5 로드 실패: $uri")
+}
+
+private fun InputStream.sha256(bufferSize: Int = 65536): String {
+    val md = MessageDigest.getInstance("SHA-256")
+    buffered(bufferSize).use { input ->
+        val buffer = ByteArray(bufferSize)
+        var read: Int
+        while (input.read(buffer).also { read = it } != -1) {
+            md.update(buffer, 0, read)
+        }
+    }
+    return md.digest().joinToString("") { "%02x".format(it) }
+}

--- a/data/src/main/java/com/wheretogo/data/feature/Network.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/Network.kt
@@ -50,3 +50,26 @@ suspend fun <T> safeApiCall(
         Result.failure(e)
     }
 }
+
+suspend fun safeMsgApiCall(
+    call: suspend () -> Response<MessageResponse>
+): Result<String> {
+    return try {
+        val response = call()
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                if(body.success)
+                    Result.success(body.message)
+                else
+                    Result.failure(response.toDataError())
+            } else {
+                Result.failure(Exception("네트워크의 결과값이 없습니다."))
+            }
+        } else {
+            return Result.failure(response.toDataError())
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/data/src/main/java/com/wheretogo/data/feature/PhotoExifReader.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/PhotoExifReader.kt
@@ -1,7 +1,7 @@
 package com.wheretogo.data.feature
 
 import androidx.exifinterface.media.ExifInterface
-import com.wheretogo.domain.model.util.ExifData
+import com.wheretogo.data.model.gallery.ExifEntity
 import java.io.File
 import java.io.InputStream
 import java.text.SimpleDateFormat
@@ -10,11 +10,11 @@ import javax.inject.Inject
 
 class PhotoExifReader @Inject constructor() {
 
-    fun read(input: InputStream): ExifData = ExifInterface(input).toExifData()
+    fun read(input: InputStream): ExifEntity = ExifInterface(input).toExifData()
 
-    fun read(file: File): ExifData = ExifInterface(file.absolutePath).toExifData()
+    fun read(file: File): ExifEntity = ExifInterface(file.absolutePath).toExifData()
 
-    private fun ExifInterface.toExifData(): ExifData {
+    private fun ExifInterface.toExifData(): ExifEntity {
         val latLong = FloatArray(2)
         val hasLocation = getLatLong(latLong)
 
@@ -39,7 +39,7 @@ class PhotoExifReader @Inject constructor() {
             ?: getAttribute(ExifInterface.TAG_DATETIME)
         val timestamp = dateTimeStr?.let { parseExifDateTime(it) }
 
-        return ExifData(
+        return ExifEntity(
             latitude = if (hasLocation) latLong[0].toDouble() else null,
             longitude = if (hasLocation) latLong[1].toDouble() else null,
             altitude = altitude,

--- a/data/src/main/java/com/wheretogo/data/feature/Storeage.kt
+++ b/data/src/main/java/com/wheretogo/data/feature/Storeage.kt
@@ -1,0 +1,51 @@
+package com.wheretogo.data.feature
+
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.decode.ImageSource
+import coil.fetch.Fetcher
+import coil.fetch.SourceResult
+import coil.map.Mapper
+import coil.request.Options
+import com.google.firebase.Firebase
+import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.storage
+import com.wheretogo.data.model.confg.ImageConfig
+import kotlinx.coroutines.tasks.await
+
+
+class StoragePathMapper : Mapper<String, StorageReference> {
+    override fun map(data: String, options: Options): StorageReference? {
+        if (!data.startsWith("/image/")) return null
+        return Firebase.storage.reference.child(data)
+    }
+}
+
+class StorageReferenceFetcher(
+    private val data: StorageReference,
+    private val imgConfig: ImageConfig,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): SourceResult {
+        val bytes =
+            data.getBytes(imgConfig.maxDownMB.toLong() * 1024 * 1024).await()
+
+        return SourceResult(
+            source = ImageSource(
+                source = okio.Buffer().apply { write(bytes) },
+                context = options.context,
+            ),
+            mimeType = null,
+            dataSource = DataSource.NETWORK,
+        )
+    }
+
+    class Factory(val imgConfig: ImageConfig) : Fetcher.Factory<StorageReference> {
+        override fun create(
+            data: StorageReference,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Fetcher = StorageReferenceFetcher(data, imgConfig,options)
+    }
+}

--- a/data/src/main/java/com/wheretogo/data/model/gallery/EncodedImage.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/EncodedImage.kt
@@ -4,4 +4,5 @@ import com.wheretogo.domain.ImageSize
 
 data class EncodedImage(
     val images: Map<ImageSize, ByteArray>,
+    val sha256 :String
 )

--- a/data/src/main/java/com/wheretogo/data/model/gallery/ExifEntity.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/ExifEntity.kt
@@ -1,0 +1,18 @@
+package com.wheretogo.data.model.gallery
+
+data class ExifEntity(
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val altitude: Double? = null,
+    val dateTimeOriginal: String? = null,
+    val timestampMillis: Long? = null,
+    val make: String? = null,
+    val model: String? = null,
+    val orientation: Int? = null,
+    val imageWidth: Int? = null,
+    val imageHeight: Int? = null,
+    val fNumber: String? = null,
+    val exposureTime: String? = null,
+    val iso: String? = null,
+    val focalLength: String? = null,
+)

--- a/data/src/main/java/com/wheretogo/data/model/gallery/ExifResponse.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/ExifResponse.kt
@@ -1,0 +1,18 @@
+package com.wheretogo.data.model.gallery
+
+data class ExifResponse(
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val altitude: Double? = null,
+    val dateTimeOriginal: String? = null,
+    val timestampMillis: Long? = null,
+    val make: String? = null,
+    val model: String? = null,
+    val orientation: Int? = null,
+    val imageWidth: Int? = null,
+    val imageHeight: Int? = null,
+    val fNumber: String? = null,
+    val exposureTime: String? = null,
+    val iso: String? = null,
+    val focalLength: String? = null,
+)

--- a/data/src/main/java/com/wheretogo/data/model/gallery/ImageMetaCreateContent.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/ImageMetaCreateContent.kt
@@ -1,0 +1,12 @@
+package com.wheretogo.data.model.gallery
+
+import com.wheretogo.domain.model.util.ExifData
+
+data class ImageMetaCreateContent(
+    val imageId: String,
+    val exif: ExifData,
+    val sha256: String,
+    val address: String,
+    val createAt: Long,
+    val userId: String? = null,
+)

--- a/data/src/main/java/com/wheretogo/data/model/gallery/ImageMetaResponse.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/ImageMetaResponse.kt
@@ -1,0 +1,10 @@
+package com.wheretogo.data.model.gallery
+
+data class ImageMetaResponse(
+    val imageId: String = "",
+    val userId: String = "",
+    val sha256: String = "",
+    val exif: ExifResponse = ExifResponse(),
+    val address: String = "",
+    val createAt: Long = 0
+)

--- a/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
@@ -18,4 +18,6 @@ data class PhotoEntity(
     val height: Int?,
     val latitude: Double?,
     val longitude: Double?,
+    val courseId: String? = null,
+    val courseName: String? = null
 )

--- a/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
@@ -1,24 +1,27 @@
 package com.wheretogo.data.model.gallery
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
-    tableName = "gallery_photo",
-    indices = [Index(value = ["sourceKey"], unique = true)],
+    tableName = "photo",
+    indices = [
+        Index(value = ["sha256"], unique = true),
+        Index(value = ["sourceKey"], unique = true)
+    ]
 )
 data class PhotoEntity(
-    @PrimaryKey val id: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val imageId: String,
-    val fileName: String,
-    val sourceKey: String,        // 중복 판단용
-    val dateTaken: Long?,
-    val width: Int?,
-    val height: Int?,
-    val latitude: Double?,
-    val longitude: Double?,
+    val sha256: String,             // 비트 기반
+    val sourceKey: String? = null,  // uri 기반 중복 판단용
+    val uriString: String? = null,
+    val thumbnail: String? = null,
+    @Embedded val exif: ExifEntity? = null,
     val courseId: String? = null,
     val courseName: String? = null,
-    val address: String? = null
+    val checkPointId: String? = null,
+    val address: String? = null,
 )

--- a/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
+++ b/data/src/main/java/com/wheretogo/data/model/gallery/PhotoEntity.kt
@@ -19,5 +19,6 @@ data class PhotoEntity(
     val latitude: Double?,
     val longitude: Double?,
     val courseId: String? = null,
-    val courseName: String? = null
+    val courseName: String? = null,
+    val address: String? = null
 )

--- a/data/src/main/java/com/wheretogo/data/network/PrivateInterceptor.kt
+++ b/data/src/main/java/com/wheretogo/data/network/PrivateInterceptor.kt
@@ -24,7 +24,7 @@ class PrivateInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val authResponse = chain.proceed(chain.request().authRequest())
 
-        if (authResponse.code() != 401) return authResponse
+        if (authResponse.code != 401) return authResponse
         authResponse.close()
 
         // 만료시 재시도
@@ -73,15 +73,15 @@ class PrivateInterceptor @Inject constructor(
 // 디버깅용
 fun Request.log(tag: String = "tst_"): Request {
     println("$tag ┌──────────────── REQUEST ────────────────")
-    try { println("$tag │ ${method()} ${url()}") } catch (e: Exception) { println("$tag │ method/url 오류: ${e.message}") }
+    try { println("$tag │ ${method} ${url}") } catch (e: Exception) { println("$tag │ method/url 오류: ${e.message}") }
     try {
         println("$tag │ Headers:")
-        val h = headers()
-        for (i in 0 until h.size()) println("$tag │   ${h.name(i)}: ${h.value(i)}")
+        val h = headers
+        for (i in 0 until h.size) println("$tag │   ${h.name(i)}: ${h.value(i)}")
     } catch (e: Exception) { println("$tag │ Headers 오류: ${e.message}") }
     try {
         val buf = okio.Buffer()
-        body()?.writeTo(buf)
+        body?.writeTo(buf)
         println("$tag │ Body: ${buf.readUtf8().ifBlank { "<empty>" }}")
     } catch (e: Exception) { println("$tag │ Body 오류: ${e.message}") }
     println("$tag └─────────────────────────────────────────")

--- a/data/src/main/java/com/wheretogo/data/network/PublicInterceptor.kt
+++ b/data/src/main/java/com/wheretogo/data/network/PublicInterceptor.kt
@@ -17,7 +17,7 @@ class PublicInterceptor @Inject constructor(
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val authResponse = chain.proceed(chain.request().authRequest())
-        if (authResponse.code() != 401 ||
+        if (authResponse.code != 401 ||
             authResponse.header("WWW-Authenticate")?.contains("invalid_token") != true
         ) return authResponse
         authResponse.close()

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
@@ -31,14 +31,13 @@ class CheckPointRepositoryImpl @Inject constructor(
         checkPointId: String,
         isRemote: Boolean
     ): Result<CheckPoint?> {
-        return if (isRemote) {
-            runCatching {
-                fetchCheckPoint(listOf(checkPointId)).firstOrNull()
-            }
-        } else {
-            checkPointLocalDatasource.getCheckPoints(listOf(checkPointId))
-                .map { it.firstOrNull() }
-        }.map { it?.toCheckPoint() }.mapDomainError()
+       return runCatching {
+            val local= checkPointLocalDatasource.getCheckPoints(listOf(checkPointId))
+                .map { it.firstOrNull() }.getOrNull()
+           if (local == null && isRemote) {
+               fetchCheckPoint(listOf(checkPointId)).firstOrNull()
+           } else local
+        }.map { it?.toCheckPoint() }
     }
 
     override suspend fun getCheckPointGroupByCourseId(courseId: String): Result<List<CheckPoint>> {

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.wheretogo.data.repositoryimpl
 
 import com.wheretogo.data.CachePolicy
-import com.wheretogo.data.DataError
 import com.wheretogo.data.datasource.CheckPointLocalDatasource
 import com.wheretogo.data.datasource.CheckPointRemoteDatasource
 import com.wheretogo.data.di.CheckpointCache
@@ -40,6 +39,18 @@ class CheckPointRepositoryImpl @Inject constructor(
         }.map { it?.toCheckPoint() }
     }
 
+    override suspend fun getCheckPoints(
+        checkPointIds: List<String>,
+    ): Result<List<CheckPoint>> {
+        return runCatching {
+            val local= checkPointLocalDatasource.getCheckPoints(checkPointIds).getOrThrow()
+            val missingIds = local.map { it.checkPointId }.filter { !checkPointIds.contains(it) }
+            if (missingIds.isNotEmpty()) {
+                fetchCheckPoint(missingIds)
+            } else local
+        }.map { it.toDomain() }
+    }
+
     override suspend fun getCheckPointGroupByCourseId(courseId: String): Result<List<CheckPoint>> {
         val localGroup = checkPointLocalDatasource.getCluster(courseId).getOrNull()
         return if (localGroup == null || localGroup.isExpired(cachePolicy)) {
@@ -59,8 +70,7 @@ class CheckPointRepositoryImpl @Inject constructor(
                 val local = remote.toLocalCheckPoint()
                 checkPointLocalDatasource.saveCheckPoints(listOf(local)).map { local }
             }.mapCatching { local ->
-                val imageLocalPath = request.thumbnail
-                local.toCheckPoint(imageLocalPath)
+                local.toCheckPoint()
             }.mapDataError().mapDomainError()
     }
 

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
@@ -30,16 +30,15 @@ class CheckPointRepositoryImpl @Inject constructor(
     override suspend fun getCheckPoint(
         checkPointId: String,
         isRemote: Boolean
-    ): Result<CheckPoint> {
+    ): Result<CheckPoint?> {
         return if (isRemote) {
             runCatching {
                 fetchCheckPoint(listOf(checkPointId)).firstOrNull()
-                    ?: throw DataError.NotFound("$checkPointId NOT_FOUND")
             }
         } else {
             checkPointLocalDatasource.getCheckPoints(listOf(checkPointId))
-                .map { it.firstOrNull() ?: throw DataError.NotFound("$checkPointId NOT_FOUND") }
-        }.map { it.toCheckPoint() }.mapDomainError()
+                .map { it.firstOrNull() }
+        }.map { it?.toCheckPoint() }.mapDomainError()
     }
 
     override suspend fun getCheckPointGroupByCourseId(courseId: String): Result<List<CheckPoint>> {

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/CheckPointRepositoryImpl.kt
@@ -64,8 +64,8 @@ class CheckPointRepositoryImpl @Inject constructor(
             }.mapDataError().mapDomainError()
     }
 
-    override suspend fun removeCheckPoint(checkPointId: String): Result<Unit> {
-        return checkPointRemoteDatasource.removeCheckPoint(checkPointId)
+    override suspend fun removeCheckPoint(checkPointId: String, courseId: String): Result<Unit> {
+        return checkPointRemoteDatasource.removeCheckPoint(checkPointId, courseId)
             .mapSuccess {
                 checkPointLocalDatasource.deleteCheckPoints(listOf(checkPointId))
             }.mapDataError().mapDomainError()

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -7,18 +7,25 @@ import com.wheretogo.data.datasource.ImageRemoteDatasource
 import com.wheretogo.data.feature.mapDataError
 import com.wheretogo.data.feature.mapDomainError
 import com.wheretogo.data.feature.mapSuccess
+import com.wheretogo.data.model.gallery.PhotoEntity
+import com.wheretogo.data.toCreateContent
+import com.wheretogo.data.toDomain
+import com.wheretogo.data.toGalleryPhoto
+import com.wheretogo.data.toPhotoEntity
 import com.wheretogo.domain.ImageSize
 import com.wheretogo.domain.feature.flatMap
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.util.ExifData
+import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.ImageUris
 import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.repository.ImageRepository
-import com.wheretogo.domain.model.util.ExifData
-import com.wheretogo.domain.model.util.FilePreview
-import com.wheretogo.domain.model.gallery.GalleryPhoto
 import de.huxhorn.sulky.ulid.ULID
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -47,12 +54,12 @@ class ImageRepositoryImpl @Inject constructor(
     override suspend fun setImage(imgUriString: String): Result<ImageUris> {
         val imageId = generateId()
         return runCatching {
-            val resizedImages =
-                imageLocalDatasource.openAndResizeImage(imgUriString, ImageSize.entries)
+            val encodedImages =
+                imageLocalDatasource.encodeImage(imgUriString, ImageSize.entries)
                     .getOrThrow()
 
             val imagePaths = coroutineScope {
-                resizedImages.images.map { (size, bytes) ->
+                encodedImages.images.map { (size, bytes) ->
                     async { uploadAndSaveImage(imageId, size, bytes) }
                 }.awaitAll()
             }
@@ -63,8 +70,102 @@ class ImageRepositoryImpl @Inject constructor(
         }.mapDataError().mapDomainError()
     }
 
+
+    override suspend fun setRemoteImage(imageId: String): Result<ImageUris> {
+        return runCatching {
+            coroutineScope {
+                val imagePaths=  ImageSize.entries.map { size->
+                    async {
+                        val file = imageLocalDatasource.getImage(imageId,size)
+                        if(!file.exists())
+                            throw DataError.NotFound("$imageId not found")
+                        imageRemoteDatasource.uploadImageByFile(file, imageId, size)
+                        size to file.toUri().toString()
+                    }
+                }.awaitAll()
+                ImageUris(imageId, imagePaths.toMap())
+            }
+        }.onFailure {
+            coroutineScope { launch { removeImage(imageId) } }
+        }.mapDataError().mapDomainError()
+    }
+
+    override suspend fun setRemoteImageWithMeta(imageId: String, userId:String): Result<ImageUris> {
+        return runCatching {
+            coroutineScope {
+                val metaDeprecated= async {
+                    val entity= imageLocalDatasource.getPhotosByImageId(listOf(imageId)).getOrThrow().firstOrNull()
+                    if(entity== null || entity.exif == null)
+                        throw DataError.NotFound("$imageId not found")
+                    val content = entity.toCreateContent().copy(userId = userId)
+                    imageRemoteDatasource.setImageMetas(listOf(content))
+                }
+                val imagePaths=  ImageSize.entries.map { size->
+                    async {
+                        val file = imageLocalDatasource.getImage(imageId,size)
+                        if(!file.exists())
+                            throw DataError.NotFound("$imageId not found")
+                        imageRemoteDatasource.uploadImageByFile(file, imageId, size)
+                        size to file.toUri().toString()
+                    }
+                }.awaitAll()
+                metaDeprecated.await()
+                ImageUris(imageId, imagePaths.toMap())
+            }
+        }.onFailure {
+            coroutineScope { launch { removeImageWithMeta(imageId) } }
+        }.mapDataError().mapDomainError()
+    }
+
+    override suspend fun removeRemoteImage(imageId: String): Result<Unit> {
+        return runCatching {
+            coroutineScope {
+                ImageSize.entries.map { size ->
+                    async {
+                        imageRemoteDatasource.removeImage(imageId, size)
+                    }
+                }.awaitAll().flatMap()
+            }
+        }
+    }
+
+
     override suspend fun loadGalleyPhotos(): Result<List<GalleryPhoto>> {
-        return imageLocalDatasource.loadGalleyPhotos()
+        return imageLocalDatasource.loadAllPhotos().map { it.mapNotNull { it.toGalleryPhoto() } }
+    }
+
+    override fun observeGalleryPhotos(): Flow<List<GalleryPhoto>> {
+        return imageLocalDatasource.observePhotos().map { entities ->
+            entities.mapNotNull { it.toGalleryPhoto() }
+        }
+    }
+
+    override suspend fun refreshGalleyPhotosByUserId(userId: String): Result<Unit> {
+        return runCatching {
+            coroutineScope {
+                val response= imageRemoteDatasource.getImageMetasByUserId(userId).getOrThrow()
+                val entity= imageLocalDatasource.getPhotosByHash(response.map { it.sha256 }).getOrThrow()
+                val merge=
+                    response.map { res->
+                        val local = entity.firstOrNull{ it.sha256 == res.sha256 }
+                        async {
+                            if(local == null){
+                                val small = getImage(res.imageId, ImageSize.SMALL).getOrThrow().toUri().toString()
+                                val normal = getImage(res.imageId, ImageSize.NORMAL).getOrThrow().toUri().toString()
+                                res.toPhotoEntity().copy(
+                                    imageId = res.imageId,
+                                    thumbnail = small,
+                                    uriString = normal,
+                                )
+                            } else {
+                                local.copy(imageId = res.imageId)
+                            }
+                        }
+                    }.awaitAll()
+                imageLocalDatasource.upsertPhotos(merge)
+            }
+
+        }
     }
 
     override suspend fun saveGalleryPhotos(imgUriStrings: List<String>): Result<List<Long>> {
@@ -72,7 +173,16 @@ class ImageRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit> {
-        return imageLocalDatasource.updateGalleryPhotos(photos)
+        val entities= photos.map {
+            PhotoEntity(
+                id = it.entityId,
+                sha256 = it.sha256,
+                imageId = it.imageId,
+                courseId = it.courseId,
+                courseName = it.courseName,
+            )
+        }
+        return imageLocalDatasource.updatePhotos(entities)
     }
 
     override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
@@ -91,8 +201,33 @@ class ImageRepositoryImpl @Inject constructor(
         }.mapCatching { Unit }.mapDataError().mapDomainError()
     }
 
+    override suspend fun removeLocalImage(imageId: String): Result<Unit> {
+        return coroutineScope {
+            ImageSize.entries.map { size ->
+                async {
+                    imageLocalDatasource.removeImage(imageId, size)
+                }
+            }.awaitAll().flatMap()
+        }.mapCatching { Unit }.mapDataError().mapDomainError()
+    }
+
+    override suspend fun removeImageWithMeta(imageId: String): Result<Unit> {
+        return coroutineScope {
+            launch {
+                imageRemoteDatasource.removeImageMetas(listOf(imageId))
+            }
+            ImageSize.entries.map { size ->
+                async {
+                    imageRemoteDatasource.removeImage(imageId, size).mapSuccess {
+                        imageLocalDatasource.removeImage(imageId, size)
+                    }
+                }
+            }.awaitAll().flatMap()
+        }.mapCatching {}.mapDataError().mapDomainError()
+    }
+
     override suspend fun getExif(imageUriString: String): Result<ExifData> {
-        return imageLocalDatasource.getExif(imageUriString)
+        return imageLocalDatasource.getExif(imageUriString).map { it.toDomain() }
     }
 
     override suspend fun getPreview(imageUriString: String): Result<FilePreview> {
@@ -107,7 +242,7 @@ class ImageRepositoryImpl @Inject constructor(
     }
 
     private suspend fun uploadAndSaveImage(imageId: String, size: ImageSize, bytes: ByteArray): Pair<ImageSize, String> {
-        imageRemoteDatasource.uploadImage(bytes, imageId, size).getOrThrow()
+        imageRemoteDatasource.uploadImageByByteArray(bytes, imageId, size).getOrThrow()
         return imageLocalDatasource.saveImage(bytes, imageId, size).getOrThrow()
             .run {
                val path= toUri().path ?: throw DataError.InternalError("이미지 저장 실패: $size")

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/ImageRepositoryImpl.kt
@@ -71,6 +71,10 @@ class ImageRepositoryImpl @Inject constructor(
         return imageLocalDatasource.saveGalleryPhotos(imgUriStrings)
     }
 
+    override suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit> {
+        return imageLocalDatasource.updateGalleryPhotos(photos)
+    }
+
     override suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>> {
         return imageLocalDatasource.clearGalleryPhotos(ids)
     }

--- a/data/src/main/java/com/wheretogo/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/wheretogo/data/repositoryimpl/UserRepositoryImpl.kt
@@ -82,6 +82,11 @@ class UserRepositoryImpl @Inject constructor(
         }.mapDomainError()
     }
 
+    override fun observeHistory(type: HistoryType): Flow<HistoryGroupWrapper> {
+        return userLocalDatasource.observeHistory(type.toDataHistoryType())
+            .map { local -> local.toHistoryGroupWrapper() }
+    }
+
     override suspend fun addHistory(
         type: HistoryType,
         groupId:String,

--- a/domain/src/main/java/com/wheretogo/domain/DomainMapper.kt
+++ b/domain/src/main/java/com/wheretogo/domain/DomainMapper.kt
@@ -35,7 +35,6 @@ fun CourseContent.toCourseAddRequest(
 }
 
 fun CheckPointContent.toAddRequest(
-    thumbnail: String,
     imageId: String,
     groupId: String? = null, // 선택된 코스에서 실제 Id 삽입시 사용
 ): CheckPointAddRequest {
@@ -48,7 +47,6 @@ fun CheckPointContent.toAddRequest(
     return CheckPointAddRequest(
         content = content,
         imageId = imageId,
-        thumbnail = thumbnail,
     )
 }
 

--- a/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/wheretogo/domain/di/UseCaseModule.kt
@@ -18,8 +18,10 @@ import com.wheretogo.domain.usecase.comment.GetCommentForCheckPointUseCase
 import com.wheretogo.domain.usecase.comment.RemoveCommentToCheckPointUseCase
 import com.wheretogo.domain.usecase.course.AddCourseUseCase
 import com.wheretogo.domain.usecase.course.FilterListCourseUseCase
+import com.wheretogo.domain.usecase.course.GetCourseUseCase
 import com.wheretogo.domain.usecase.course.GetNearByCourseUseCase
 import com.wheretogo.domain.usecase.course.RemoveCourseUseCase
+import com.wheretogo.domain.usecase.gallery.GetStampUseCase
 import com.wheretogo.domain.usecase.report.ReportContentUseCase
 import com.wheretogo.domain.usecase.user.DeleteUserUseCase
 import com.wheretogo.domain.usecase.user.GetUserProfileStreamUseCase
@@ -47,8 +49,10 @@ import com.wheretogo.domain.usecaseimpl.comment.GetCommentForCheckPointUseCaseIm
 import com.wheretogo.domain.usecaseimpl.comment.RemoveCommentToCheckPointUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.course.AddCourseUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.course.FilterListCourseUseCaseImpl
+import com.wheretogo.domain.usecaseimpl.course.GetCourseUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.course.GetNearByCourseUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.course.RemoveCourseUseCaseImpl
+import com.wheretogo.domain.usecaseimpl.gallery.GetStampUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.report.ReportContentUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.user.DeleteUserUseCaseImpl
 import com.wheretogo.domain.usecaseimpl.user.GetUserProfileStreamUseCaseImpl
@@ -92,7 +96,10 @@ abstract class UseCaseModule {
 
 
     @Binds
-    abstract fun bindGetNearByJourneyUseCase(useCaseImpl: GetNearByCourseUseCaseImpl): GetNearByCourseUseCase
+    abstract fun bindGetNearByCourseUseCase(useCaseImpl: GetNearByCourseUseCaseImpl): GetNearByCourseUseCase
+
+    @Binds
+    abstract fun bindGetCourseUseCase(useCaseImpl: GetCourseUseCaseImpl): GetCourseUseCase
 
     @Binds
     abstract fun bindUserSignOutUseCase(useCaseImpl: UserSignOutUseCaseImpl): UserSignOutUseCase
@@ -171,6 +178,9 @@ abstract class UseCaseModule {
 
     @Binds
     abstract fun bindDeleteGalleryPhotosUseCase(useCaseImpl: DeleteGalleryPhotosUseCaseImpl): DeleteGalleryPhotosUseCase
+
+    @Binds
+    abstract fun bindGetStampUseCase(useCaseImpl: GetStampUseCaseImpl): GetStampUseCase
 
 }
 

--- a/domain/src/main/java/com/wheretogo/domain/model/checkpoint/CheckPointAddRequest.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/checkpoint/CheckPointAddRequest.kt
@@ -3,8 +3,7 @@ package com.wheretogo.domain.model.checkpoint
 
 data class CheckPointAddRequest(
     val content: CheckPointContent,
-    val imageId: String,
-    val thumbnail: String
+    val imageId: String
 ) {
     fun valid(): CheckPointAddRequest {
         require(content.latLng.latitude != 0.0) { "inValid latLng" }
@@ -28,7 +27,6 @@ data class CheckPointAddRequest(
             captionId = "",
             caption = "",
             imageId = imageId,
-            thumbnail = thumbnail,
             description = "",
             isUserCreated = true,
             isHide = false,

--- a/domain/src/main/java/com/wheretogo/domain/model/checkpoint/CheckPointContent.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/checkpoint/CheckPointContent.kt
@@ -4,7 +4,8 @@ import com.wheretogo.domain.model.address.LatLng
 
 data class CheckPointContent(
     val groupId: String,
-    val imgUriString: String,
     val latLng: LatLng,
     val description: String,
+    val imgUriString: String? = null,
+    val imageId: String? = null // 이미 존재하는 이미지로 추가
 )

--- a/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
@@ -1,12 +1,21 @@
 package com.wheretogo.domain.model.gallery
 
 data class GalleryPhoto(
-    val id: Long, // 시스템 picker id
-    val imageId: String = "",
-    val uriString: String,
-    val thumbnail:String = "",
-    val courseId:String? = null,
-    val courseName:String? = null,
-    val address: String? = null,
+    val id: Long,
     val exif: PhotoExif,
-)
+    val imageId: String,
+    val sha256: String,
+    val entityId: Long,
+    val imageSource: String? = null, // uriString, 파이어베이스 스토리지 상대 경로
+    val thumbnail: String? = null,   // 로컬 uri 주소
+    val courseId: String? = null,
+    val courseName: String? = null,
+    val address: String? = null,
+    val isStampedGroup: Boolean? = null
+){
+    fun simpleAddress(drop:Int = 1, take:Int = 2) : String? =
+        address?.split(" ")
+            ?.drop(drop)
+            ?.take(take)
+            ?.joinToString(" ")
+}

--- a/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/gallery/GalleryPhoto.kt
@@ -7,5 +7,6 @@ data class GalleryPhoto(
     val thumbnail:String = "",
     val courseId:String? = null,
     val courseName:String? = null,
+    val address: String? = null,
     val exif: PhotoExif,
 )

--- a/domain/src/main/java/com/wheretogo/domain/model/gallery/Stamp.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/gallery/Stamp.kt
@@ -1,0 +1,11 @@
+package com.wheretogo.domain.model.gallery
+
+data class Stamp(
+    val id: String,
+    val courseId: String,
+    val pickerId: Long? = null,
+    val thumbnail: String? = null,
+    val description: String = "",
+    val visitedCount: Int = 0,
+    val createAt: Long = 0L,
+)

--- a/domain/src/main/java/com/wheretogo/domain/model/util/ImageUris.kt
+++ b/domain/src/main/java/com/wheretogo/domain/model/util/ImageUris.kt
@@ -2,4 +2,7 @@ package com.wheretogo.domain.model.util
 
 import com.wheretogo.domain.ImageSize
 
-data class ImageUris(val imageId:String, val uriPathGroup: Map<ImageSize, String>)
+data class ImageUris(
+    val imageId: String,
+    val uriPathGroup: Map<ImageSize, String>
+)

--- a/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
@@ -11,7 +11,7 @@ interface CheckPointRepository {
 
     suspend fun addCheckPoint(request: CheckPointAddRequest): Result<CheckPoint>
 
-    suspend fun removeCheckPoint(checkPointId: String): Result<Unit>
+    suspend fun removeCheckPoint(checkPointId: String, courseId: String): Result<Unit>
 
     suspend fun refreshCheckPoint(checkpointIds: List<String>): Result<Unit>
 

--- a/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
@@ -9,6 +9,8 @@ interface CheckPointRepository {
 
     suspend fun getCheckPoint(checkPointId: String, isRemote: Boolean): Result<CheckPoint?>
 
+    suspend fun getCheckPoints(checkPointIds: List<String>): Result<List<CheckPoint>>
+
     suspend fun addCheckPoint(request: CheckPointAddRequest): Result<CheckPoint>
 
     suspend fun removeCheckPoint(checkPointId: String, courseId: String): Result<Unit>

--- a/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/CheckPointRepository.kt
@@ -7,7 +7,7 @@ interface CheckPointRepository {
 
     suspend fun getCheckPointGroupByCourseId(courseId: String): Result<List<CheckPoint>>
 
-    suspend fun getCheckPoint(checkPointId: String, isRemote: Boolean): Result<CheckPoint>
+    suspend fun getCheckPoint(checkPointId: String, isRemote: Boolean): Result<CheckPoint?>
 
     suspend fun addCheckPoint(request: CheckPointAddRequest): Result<CheckPoint>
 

--- a/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
@@ -6,17 +6,26 @@ import com.wheretogo.domain.model.util.FilePreview
 import com.wheretogo.domain.model.util.ImageUris
 import com.wheretogo.domain.model.util.MediaImage
 import com.wheretogo.domain.model.gallery.GalleryPhoto
+import kotlinx.coroutines.flow.Flow
 
 interface ImageRepository {
     suspend fun getImage(imageId: String, size: ImageSize): Result<String>
     suspend fun setImage(imgUriString: String): Result<ImageUris>
     suspend fun removeImage(imageId: String): Result<Unit>
+    suspend fun removeLocalImage(imageId: String): Result<Unit>
+    suspend fun removeImageWithMeta(imageId: String): Result<Unit>
+
+    suspend fun setRemoteImage(imageId: String): Result<ImageUris>
+    suspend fun setRemoteImageWithMeta(imageId: String, userId:String): Result<ImageUris>
+    suspend fun removeRemoteImage(imageId: String): Result<Unit>
 
     suspend fun getExif(imageUriString: String): Result<ExifData>
     suspend fun getPreview(imageUriString: String): Result<FilePreview>
     suspend fun getMediaImages(offset: Int, limit: Int): Result<List<MediaImage>>
 
     suspend fun loadGalleyPhotos():Result<List<GalleryPhoto>>
+    fun observeGalleryPhotos(): Flow<List<GalleryPhoto>>
+    suspend fun refreshGalleyPhotosByUserId(userId: String):Result<Unit>
     suspend fun saveGalleryPhotos(imgUriStrings: List<String>): Result<List<Long>>
     suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit>
     suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>

--- a/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/ImageRepository.kt
@@ -18,5 +18,6 @@ interface ImageRepository {
 
     suspend fun loadGalleyPhotos():Result<List<GalleryPhoto>>
     suspend fun saveGalleryPhotos(imgUriStrings: List<String>): Result<List<Long>>
+    suspend fun updateGalleryPhotos(photos: List<GalleryPhoto>): Result<Unit>
     suspend fun clearGalleryPhotos(ids: Set<Long>): Result<Set<Long>>
 }

--- a/domain/src/main/java/com/wheretogo/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/wheretogo/domain/repository/UserRepository.kt
@@ -19,6 +19,8 @@ interface UserRepository {
 
     suspend fun getHistory(type: HistoryType): Result<HistoryGroupWrapper>
 
+    fun observeHistory(type: HistoryType): Flow<HistoryGroupWrapper>
+
     suspend fun addHistory(
         type: HistoryType,
         groupId: String,

--- a/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/AddCheckpointToCourseUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/AddCheckpointToCourseUseCase.kt
@@ -4,7 +4,6 @@ import com.wheretogo.domain.model.checkpoint.CheckPoint
 import com.wheretogo.domain.model.checkpoint.CheckPointContent
 
 interface AddCheckpointToCourseUseCase {
-    suspend operator fun invoke(
-        content: CheckPointContent
-    ): Result<CheckPoint>
+    suspend operator fun invoke(content: CheckPointContent): Result<CheckPoint>
+    suspend fun stamp(content: CheckPointContent): Result<CheckPoint>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/RemoveCheckPointUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/RemoveCheckPointUseCase.kt
@@ -3,4 +3,5 @@ package com.wheretogo.domain.usecase.checkpoint
 interface RemoveCheckPointUseCase {
     suspend operator fun invoke(checkPointId: String): Result<String>
     suspend fun bySelect(): Result<String>
+    suspend fun unStamp(checkPointId: String): Result<String>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/RemoveCheckPointUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/checkpoint/RemoveCheckPointUseCase.kt
@@ -1,6 +1,6 @@
 package com.wheretogo.domain.usecase.checkpoint
 
 interface RemoveCheckPointUseCase {
-    suspend operator fun invoke(courseId: String, checkPointId: String): Result<String>
+    suspend operator fun invoke(checkPointId: String): Result<String>
     suspend fun bySelect(): Result<String>
 }

--- a/domain/src/main/java/com/wheretogo/domain/usecase/course/GetCourseUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/course/GetCourseUseCase.kt
@@ -1,0 +1,7 @@
+package com.wheretogo.domain.usecase.course
+
+import com.wheretogo.domain.model.course.Course
+
+interface GetCourseUseCase {
+    suspend operator fun invoke(courseId: String): Result<Course>
+}

--- a/domain/src/main/java/com/wheretogo/domain/usecase/gallery/GetStampUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/gallery/GetStampUseCase.kt
@@ -1,0 +1,8 @@
+package com.wheretogo.domain.usecase.gallery
+
+import com.wheretogo.domain.model.gallery.Stamp
+
+interface GetStampUseCase {
+    suspend operator fun invoke(courseId: String): Result<Stamp?>
+    suspend fun getGroupByCourseId(): Result<Map<String, HashSet<String>>>
+}

--- a/domain/src/main/java/com/wheretogo/domain/usecase/gallery/LoadGalleryPhotosUseCase.kt
+++ b/domain/src/main/java/com/wheretogo/domain/usecase/gallery/LoadGalleryPhotosUseCase.kt
@@ -1,7 +1,9 @@
 package com.wheretogo.domain.usecase.gallery
 
 import com.wheretogo.domain.model.gallery.GalleryPhoto
+import kotlinx.coroutines.flow.Flow
 
 interface LoadGalleryPhotosUseCase {
-    suspend operator fun invoke(): Result<List<GalleryPhoto>>
+    fun observe(): Flow<List<GalleryPhoto>>
+    suspend fun groupRefresh(forceRefresh: Boolean = false): Result<Unit>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -134,6 +134,7 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 
 # Dagger / Hilt
 dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.paging.common)
     implementation(libs.androidx.paging.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/PresentationPolicy.kt
@@ -1,6 +1,7 @@
 package com.wheretogo.presentation
 
 import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.ACCESS_MEDIA_LOCATION
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
 import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
@@ -114,6 +115,7 @@ sealed class AppPermission(val names: List<String>) {
             val api = Build.VERSION.SDK_INT
             if (api >= 34) add(READ_MEDIA_VISUAL_USER_SELECTED)
             if (api >= 33) add(READ_MEDIA_IMAGES)
+            if (api >= 29) add(ACCESS_MEDIA_LOCATION)
             if (api >= 16 && api < 33) add(READ_EXTERNAL_STORAGE)
         }
     )

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
@@ -83,6 +83,7 @@ import com.wheretogo.presentation.feature.intervalTab
 import com.wheretogo.presentation.intent.CourseAddIntent
 import com.wheretogo.presentation.model.ContentPadding
 import com.wheretogo.presentation.model.MapOverlay
+import com.wheretogo.presentation.model.NaverMapStyle
 import com.wheretogo.presentation.model.SearchBarItem
 import com.wheretogo.presentation.state.BottomSheetState
 import com.wheretogo.presentation.state.CourseAddScreenState
@@ -190,6 +191,7 @@ fun CourseAddSheetContent(
                 modifier = Modifier
                     .zIndex(0f)
                     .fillMaxSize(),
+                style = NaverMapStyle.Basic.copy(zoomControlEnabled = state.isTestUi),
                 overlayGroup = overlays,
                 fingerPrint = fingerPrint,
                 event = mapEvent,

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/CourseAddScreen.kt
@@ -101,7 +101,7 @@ fun CourseAddScreen(
     viewModel: CourseAddViewModel = hiltViewModel()
 ) {
     val state by viewModel.courseAddScreenState.collectAsState()
-
+    val fingerPrint by viewModel.fingerPrint.collectAsState()
     LifecycleDisposer {
         viewModel.handleIntent(CourseAddIntent.LifecycleChange(it))
     }
@@ -110,7 +110,7 @@ fun CourseAddScreen(
         state = state,
         mapEvent = viewModel.mapEvent,
         overlays = viewModel.overlays,
-        fingerPrint = viewModel.fingerPrint,
+        fingerPrint = fingerPrint,
 
         //NaverMap
         onMapAsync = {},
@@ -146,7 +146,7 @@ fun CourseAddSheetContent(
     state: CourseAddScreenState = CourseAddScreenState(),
     mapEvent : SharedFlow<MapEvent>? =null,
     overlays : List<MapOverlay> = emptyList(),
-    fingerPrint : StateFlow<Int>? = null,
+    fingerPrint : Int? = null,
 
     //NaverMap
     onMapAsync: (NaverMap) -> Unit = {},
@@ -274,7 +274,7 @@ fun CourseAddSheetContent(
                                 fontSize = 16.sp
                             )
                             Text(
-                                text = "${fingerPrint?.value}",
+                                text = "$fingerPrint",
                                 fontSize = 16.sp
                             )
                         }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
@@ -82,6 +82,7 @@ import com.wheretogo.presentation.feature.consumptionEvent
 import com.wheretogo.presentation.intent.DriveScreenIntent
 import com.wheretogo.presentation.intent.MapIntent
 import com.wheretogo.presentation.model.ContentPadding
+import com.wheretogo.presentation.model.NaverMapStyle
 import com.wheretogo.presentation.model.SearchBarItem
 import com.wheretogo.presentation.model.TypeEditText
 import com.wheretogo.presentation.state.CheckPointAddState
@@ -275,6 +276,7 @@ fun DriveContent(
                         modifier = Modifier
                             .fillMaxSize()
                             .zIndex(0f),
+                        style = NaverMapStyle.Basic.copy(zoomControlEnabled = state.isTestUi),
                         overlayGroup = mapViewModel.overlays,
                         fingerPrint = mapViewModel.fingerPrint,
                         event = mapViewModel.event,

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/DriveScreen.kt
@@ -268,6 +268,7 @@ fun DriveContent(
             }
 
             if(mapViewModel!= null) {
+                val fingerPrint by mapViewModel.fingerPrint.collectAsState()
                 val mapState by mapViewModel.state.collectAsState()
                 Box(modifier = Modifier.fillMaxSize()){
                     NaverMapSheet(
@@ -278,7 +279,7 @@ fun DriveContent(
                             .zIndex(0f),
                         style = NaverMapStyle.Basic.copy(zoomControlEnabled = state.isTestUi),
                         overlayGroup = mapViewModel.overlays,
-                        fingerPrint = mapViewModel.fingerPrint,
+                        fingerPrint = fingerPrint,
                         event = mapViewModel.event,
                         contentPadding = ContentPadding(
                             start = systemBars.calculateStartPadding(LocalLayoutDirection.current),
@@ -316,7 +317,7 @@ fun DriveContent(
                                 fontSize = 50.sp
                             )
                             Text(
-                                text = "${mapViewModel.fingerPrint.value}",
+                                text = "${fingerPrint}",
                                 fontSize = 16.sp
                             )
                             mapState.naverMapState .apply {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/animation/Delay.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/animation/Delay.kt
@@ -1,0 +1,28 @@
+package com.wheretogo.presentation.composable.animation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+
+@Composable
+fun rememberDelayedState(
+    isLoading: Boolean,
+    delayMillis: Long = 300L
+): Boolean {
+    var delayedLoading by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            delay(delayMillis)
+            delayedLoading = true
+        } else {
+            delayedLoading = false
+        }
+    }
+
+    return delayedLoading
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/FloatingButton.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/FloatingButton.kt
@@ -82,8 +82,7 @@ fun FloatingButtons(
 ) {
     val scope = rememberCoroutineScope()
     val isCommentVisible = isVisible && FloatingButtonState.commentVisible.contains(state.stateMode)
-    val isCheckpointAddVisible =
-        isVisible && FloatingButtonState.checkpointAddVisible.contains(state.stateMode)
+    val isCheckpointAddVisible = false
     val isInfoVisible: Boolean =
         isVisible && FloatingButtonState.infoVisible.contains(state.stateMode)
     val isExportVisible: Boolean =

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
@@ -87,7 +87,7 @@ fun NaverMapSheet(
     modifier: Modifier = Modifier,
     style: NaverMapStyle = NaverMapStyle.Basic,
     overlayGroup: List<MapOverlay> = emptyList(),
-    fingerPrint: StateFlow<Int>? = null,
+    fingerPrint: Int? = null,
     event: SharedFlow<MapEvent>? = null,
     contentPadding: ContentPadding = ContentPadding(),
     onMapAsync: (NaverMap) -> Unit = {},
@@ -170,8 +170,8 @@ fun NaverMapSheet(
         }
 
         // 오버레이 업데이트
-        LaunchedEffect(Unit) {
-            fingerPrint?.collect {
+        LaunchedEffect(fingerPrint) {
+            if(fingerPrint!=null){
                 mapView.getMapAsync { naverMap ->
                     naverMap.overlayUpdate(
                         overlayGroup = overlayGroup,

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
@@ -46,6 +46,7 @@ import com.wheretogo.presentation.model.AppPath
 import com.wheretogo.presentation.model.CameraOption
 import com.wheretogo.presentation.model.ContentPadding
 import com.wheretogo.presentation.model.MapOverlay
+import com.wheretogo.presentation.model.NaverMapStyle
 import com.wheretogo.presentation.state.NaverMapState
 import com.wheretogo.presentation.theme.Palette
 import com.wheretogo.presentation.toCameraState
@@ -84,6 +85,7 @@ fun NaverMapSheet(
     mapView: MapView,
     state: NaverMapState,
     modifier: Modifier = Modifier,
+    style: NaverMapStyle = NaverMapStyle.Basic,
     overlayGroup: List<MapOverlay> = emptyList(),
     fingerPrint: StateFlow<Int>? = null,
     event: SharedFlow<MapEvent>? = null,
@@ -154,7 +156,7 @@ fun NaverMapSheet(
             mapView.getMapAsync { naverMap ->
                 onMapAsync(naverMap)
                 state.initCamera?.let { option -> naverMap.cameraUpdate(option) }
-                naverMap.setUiSetting(state.isZoomControl)
+                naverMap.setMapStyle(style)
                 naverMap.locationSetting(context)
                 naverMap.addCameraListener()
                 naverMap.addMapClickListener()
@@ -264,16 +266,6 @@ private fun NaverMap.setGesture(isEnable: Boolean) {
     uiSettings.isRotateGesturesEnabled = isEnable
 }
 
-private fun NaverMap.setUiSetting(isZoomControl: Boolean) {
-    uiSettings.apply {
-        isLogoClickEnabled = false
-        isLocationButtonEnabled = true
-        isZoomControlEnabled = isZoomControl
-    }
-    minZoom = ZOOM.COUNTRY.level
-    setLayerGroupEnabled(NaverMap.LAYER_GROUP_BUILDING, false)
-}
-
 private fun NaverMap.contentPaddingUpdate(density: Density, contentPadding: ContentPadding) {
     val naverMap = this
     density.run {
@@ -340,6 +332,35 @@ private fun NaverMap.cameraMove(option: CameraOption, moved: () -> Unit) {
 private fun NaverMap.cameraUpdate(option: CameraOption) {
     val naverMap = this
     naverMap.cameraPosition = option.toPosition()
+}
+
+private fun NaverMap.setMapStyle(style: NaverMapStyle) {
+    mapType = style.mapType
+
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_BUILDING, style.buildingEnabled)
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_TRANSIT, style.transitEnabled)
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_BICYCLE, style.bicycleEnabled)
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_TRAFFIC, style.trafficEnabled)
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_CADASTRAL, style.cadastralEnabled)
+    setLayerGroupEnabled(NaverMap.LAYER_GROUP_MOUNTAIN, style.mountainEnabled)
+
+    symbolScale = style.symbolScale
+    symbolPerspectiveRatio = style.symbolPerspectiveRatio
+
+    isIndoorEnabled = style.indoorEnabled
+    isNightModeEnabled = style.nightModeEnabled
+
+    uiSettings.apply {
+        isScrollGesturesEnabled = style.scrollGesturesEnabled
+        isZoomGesturesEnabled = style.zoomGesturesEnabled
+        isTiltGesturesEnabled = style.tiltGesturesEnabled
+        isRotateGesturesEnabled = style.rotateGesturesEnabled
+        isZoomControlEnabled = style.zoomControlEnabled
+        isCompassEnabled = style.compassEnabled
+        isScaleBarEnabled = style.scaleBarEnabled
+        isLocationButtonEnabled = style.locationButtonEnabled
+        isLogoClickEnabled = style.logoClickEnabled
+    }
 }
 
 private fun CameraOption.toPosition(): CameraPosition {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
@@ -32,7 +32,6 @@ import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
-import com.wheretogo.domain.ZOOM
 import com.wheretogo.domain.model.address.LatLng
 import com.wheretogo.domain.model.map.CameraState
 import com.wheretogo.domain.model.map.MarkerInfo
@@ -54,13 +53,11 @@ import com.wheretogo.presentation.toDomainLatLng
 import com.wheretogo.presentation.toNaver
 import com.wheretogo.presentation.viewmodel.MapEvent
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
 @Composable
-fun rememberMapViewWithLifecycle(
-): MapView {
+fun rememberMapViewWithLifecycle(): MapView {
     val context = LocalContext.current
     val mapView = remember {
         MapView(context).apply { id = View.generateViewId() }
@@ -157,7 +154,6 @@ fun NaverMapSheet(
                 onMapAsync(naverMap)
                 state.initCamera?.let { option -> naverMap.cameraUpdate(option) }
                 naverMap.setMapStyle(style)
-                naverMap.locationSetting(context)
                 naverMap.addCameraListener()
                 naverMap.addMapClickListener()
             }
@@ -212,7 +208,7 @@ fun NaverMapSheet(
                 when (e) {
                     // 카메라 이동 요청
                     is MapEvent.MoveCamera -> {
-                        val camera = e.cameraState
+                        val camera = e.option
                         mapView.getMapAsync { naverMap ->
                             when {
                                 isMoving -> {}
@@ -361,6 +357,9 @@ private fun NaverMap.setMapStyle(style: NaverMapStyle) {
         isLocationButtonEnabled = style.locationButtonEnabled
         isLogoClickEnabled = style.logoClickEnabled
     }
+
+    if(style.compassEnabled)
+        locationSetting(context)
 }
 
 private fun CameraOption.toPosition(): CameraPosition {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
@@ -137,7 +137,7 @@ fun NaverMapSheet(
     val isPreview = LocalInspectionMode.current
     if (isPreview) {
         Box(
-            modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .background(Palette.Green50)
         )
@@ -153,6 +153,7 @@ fun NaverMapSheet(
         DisposableEffect(mapView) {
             mapView.getMapAsync { naverMap ->
                 onMapAsync(naverMap)
+                state.initCamera?.let { option -> naverMap.cameraUpdate(option) }
                 naverMap.setUiSetting(state.isZoomControl)
                 naverMap.locationSetting(context)
                 naverMap.addCameraListener()
@@ -215,12 +216,11 @@ fun NaverMapSheet(
                                 isMoving -> {}
                                 camera.isMyLocation -> coroutineScope.launch {
                                     val latlng = getLastLatLng(context) ?: NamSan
-                                    naverMap.cameraPosition = CameraPosition(latlng, camera.zoom)
+                                    naverMap.cameraUpdate(camera.copy(latlng.toDomainLatLng()))
                                 }
 
                                 camera.moveAnimation == MoveAnimation.APP_JUMP -> {
-                                    naverMap.cameraPosition =
-                                        CameraPosition(camera.latLng.toNaver(), camera.zoom)
+                                    naverMap.cameraUpdate(camera)
                                 }
 
                                 camera.latLng != LatLng() -> {
@@ -228,7 +228,6 @@ fun NaverMapSheet(
                                     naverMap.isCameraIdlePending = true
                                     naverMap.setGesture(false)
                                     naverMap.cameraMove(camera) {
-                                        coroutineScope
                                         isMoving = false
                                         naverMap.isCameraIdlePending = false
                                         naverMap.setGesture(true)
@@ -336,6 +335,15 @@ private fun NaverMap.cameraMove(option: CameraOption, moved: () -> Unit) {
                 .cancelCallback { moved() }
         )
     }
+}
+
+private fun NaverMap.cameraUpdate(option: CameraOption) {
+    val naverMap = this
+    naverMap.cameraPosition = option.toPosition()
+}
+
+private fun CameraOption.toPosition(): CameraPosition {
+    return CameraPosition(latLng.toNaver(), zoom)
 }
 
 fun MoveAnimation.toCameraAnimation(): CameraAnimation {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/EmptyGalleryScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/EmptyGalleryScreen.kt
@@ -1,0 +1,171 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Photo
+import androidx.compose.material.icons.outlined.QuestionMark
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.theme.WhereTogoTheme
+
+@Composable
+fun EmptyGalleryScreen(
+    onFindInGalleryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 28.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                OverlappingPhotoIcons()
+
+                Spacer(Modifier.height(20.dp))
+
+                Text(
+                    text = stringResource(R.string.empty_gallery_question_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(Modifier.height(6.dp))
+
+                Text(
+                    text = stringResource(R.string.empty_gallery_question_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 20.sp
+                )
+
+                Spacer(Modifier.height(20.dp))
+
+                Button(
+                    onClick = onFindInGalleryClick,
+                    shape = RoundedCornerShape(8.dp),
+                    contentPadding = PaddingValues(horizontal = 22.dp, vertical = 11.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.empty_gallery_find_in_gallery_button),
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+
+                Spacer(Modifier.height(10.dp))
+
+                Text(
+                    text = stringResource(R.string.empty_gallery_location_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverlappingPhotoIcons(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.size(width = 96.dp, height = 56.dp)
+    ) {
+        // 뒤쪽 카드
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .rotate(-8f)
+                .size(52.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .border(
+                    width = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    shape = RoundedCornerShape(10.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Photo,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+
+        // 앞쪽 카드
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .rotate(6f)
+                .size(52.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .border(
+                    width = 0.5.dp,
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+                    shape = RoundedCornerShape(10.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.QuestionMark,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OverlappingPhotoIconsPreview() {
+    WhereTogoTheme {
+        Box(Modifier.padding(24.dp)) {
+            OverlappingPhotoIcons()
+        }
+    }
+}
+
+@Preview(widthDp = 400, heightDp = 400)
+@Composable
+private fun EmptyGalleryQuestionScreenPreview() {
+    WhereTogoTheme {
+        EmptyGalleryScreen(onFindInGalleryClick = {})
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryFlow.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryFlow.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.wheretogo.presentation.viewmodel.GalleryFlowViewModel
+import com.wheretogo.presentation.composable.content.rememberMapViewWithLifecycle
+import com.wheretogo.presentation.composable.photoviewer.PhotoViewerScreen
 import com.wheretogo.presentation.intent.GalleryIntent
+import com.wheretogo.presentation.viewmodel.GalleryFlowViewModel
 
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -23,21 +25,21 @@ import com.wheretogo.presentation.intent.GalleryIntent
 fun GalleryFlow(
     viewModel: GalleryFlowViewModel = hiltViewModel(),
 ) {
-    val selectedPhoto by viewModel.detailPhoto.collectAsState()
+    val groupPhoto by viewModel.groupPhoto.collectAsState()
     val gridState = rememberLazyGridState()
-
+    val mapView = rememberMapViewWithLifecycle()
     SharedTransitionLayout(
         modifier = Modifier.navigationBarsPadding(),
     ) {
         AnimatedContent(
-            targetState = selectedPhoto,
+            targetState = groupPhoto,
             label = "galleryFlow",
             transitionSpec = {
                 fadeIn(tween(300)) togetherWith
                 fadeOut(tween(300))
             },
-        ) { photo ->
-            if (photo == null) {
+        ) { groupPhoto ->
+            if (groupPhoto == null) {
                 GalleryScreen(
                     sharedScope = this@SharedTransitionLayout,
                     animatedScope = this@AnimatedContent,
@@ -47,10 +49,14 @@ fun GalleryFlow(
                 )
             } else {
                 PhotoViewerScreen(
-                    photo = photo,
+                    photos = groupPhoto.photos,
+                    initialIndex = groupPhoto.selectedIndex,
                     sharedScope = this@SharedTransitionLayout,
                     animatedScope = this@AnimatedContent,
-                    onClose = { viewModel.handleIntent(GalleryIntent.CloseDetail) },
+                    mapView = mapView,
+                    onClose = {
+                        viewModel.handleIntent(GalleryIntent.CloseDetail)
+                    }
                 )
             }
         }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.rounded.Verified
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -151,6 +152,9 @@ fun GalleryScreen(
                                     onClick = { viewModel.handleIntent(GalleryIntent.Refresh) }
                                 ) { Text(stringResource(R.string.retry)) }
                             }
+                        is GalleryState.Empty -> EmptyGalleryScreen(
+                            onFindInGalleryClick = { showPicker = true }
+                        )
                         is GalleryState.Success ->
                             PhotoGrid(
                                 sections = state.sections,
@@ -302,7 +306,7 @@ private fun PhotoGrid(
     ) {
         sections.forEach { section ->
             item(key = "header_${section.key}", span = { GridItemSpan(maxLineSpan) }) {
-                SectionHeader(section.title)
+                SectionHeader(section.title,section.hasStamp)
             }
             items(section.photos, key = { it.id }) { photo ->
                 PhotoCell(
@@ -321,13 +325,23 @@ private fun PhotoGrid(
 }
 
 @Composable
-private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
-    Text(
-        title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold,
+private fun SectionHeader(title: String, hasStamp: Boolean, modifier: Modifier = Modifier) {
+    Row(verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .fillMaxWidth()
-            .padding(start = 4.dp, top = 16.dp, bottom = 6.dp),
-    )
+            .padding(start = 4.dp, top = 16.dp, bottom = 6.dp)
+    ) {
+        Text(
+            title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.width(3.dp))
+        if(hasStamp)
+            Icon(
+                Icons.Rounded.Verified,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(14.dp)
+            )
+    }
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -344,6 +358,8 @@ private fun PhotoCell(
 ) {
     val haptic = LocalHapticFeedback.current
     val scale by animateFloatAsState(if (selected) 0.88f else 1f)
+    val isLocationBadge=
+        photo.exif.location != null && !selectionMode && photo.courseId.isNullOrBlank()
 
     Box(
         modifier = modifier
@@ -381,7 +397,7 @@ private fun PhotoCell(
                     .background(Color.Black.copy(alpha = 0.25f))
             )
         }
-        if (photo.exif.location != null && !selectionMode) {
+        if (isLocationBadge) {
             LocationBadge(Modifier
                 .align(Alignment.TopEnd)
                 .padding(4.dp))

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/PhotoViewerScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/PhotoViewerScreen.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.wheretogo.domain.model.gallery.GalleryPhoto
@@ -118,7 +120,9 @@ fun PhotoViewerScreen(
                     .weight(1f)
                     .verticalScroll(rememberScrollState()),
             ) {
-                settingsContent(photo)
+                Box(modifier = Modifier.boundedHeight()) {
+                    settingsContent(photo)
+                }
             }
         }
 
@@ -132,6 +136,20 @@ fun PhotoViewerScreen(
             Icon(Icons.Default.Close, contentDescription = "닫기", tint = Color.White)
         }
     }
+}
+
+fun Modifier.boundedHeight(): Modifier = layout { measurable, constraints ->
+    val safe = if (constraints.maxHeight == Constraints.Infinity) {
+        val maxH = Constraints.fitPrioritizingWidth(
+            minWidth = constraints.minWidth,
+            maxWidth = constraints.maxWidth,
+            minHeight = 0,
+            maxHeight = 100_000,
+        ).maxHeight
+        constraints.copy(maxHeight = maxH)
+    } else constraints
+    val placeable = measurable.measure(safe)
+    layout(placeable.width, placeable.height) { placeable.place(0, 0) }
 }
 
 @Stable

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/NoLocationSection.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/NoLocationSection.kt
@@ -1,0 +1,210 @@
+package com.wheretogo.presentation.composable.photoviewer
+
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.FiberManualRecord
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.VerifiedUser
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.theme.WhereTogoTheme
+
+
+@Composable
+fun NoLocationSection(
+    modifier: Modifier = Modifier,
+    onOpenCameraSettings: () -> Unit = {},
+) {
+    val cs = MaterialTheme.colorScheme
+    var reasonsExpanded by remember { mutableStateOf(false) }
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (reasonsExpanded) 180f else 0f,
+        label = "arrowRotation",
+    )
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(cs.primary.copy(alpha = 0.06f))
+                .padding(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Outlined.VerifiedUser,
+                    contentDescription = null,
+                    tint = cs.primary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    stringResource(R.string.no_location_transparency_title),
+                    color = cs.primary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            stringArrayResource(R.array.no_location_usage_chips).forEach { label ->
+                Row(
+                    Modifier.padding(vertical = 3.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Spacer(Modifier.width(2.dp))
+                    Icon(
+                        Icons.Outlined.Check,
+                        contentDescription = null,
+                        tint = cs.primary,
+                        modifier = Modifier.size(14.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        label,
+                        color = cs.primary,
+                        fontSize = 12.5.sp,
+                        lineHeight = 14.sp,
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        // 원인 섹션
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { reasonsExpanded = !reasonsExpanded }
+                .padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                stringResource(R.string.no_location_reasons_title),
+                color = cs.onSurface,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                stringResource(R.string.no_location_action_learn_more),
+                color = cs.onSurfaceVariant,
+                fontSize = 12.sp,
+            )
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                Icons.Outlined.ExpandMore,
+                contentDescription = null,
+                tint = cs.onSurfaceVariant,
+                modifier = Modifier
+                    .size(18.dp)
+                    .rotate(arrowRotation),
+            )
+        }
+
+        AnimatedVisibility(visible = reasonsExpanded) {
+            Column {
+                Spacer(Modifier.height(6.dp))
+                stringArrayResource(R.array.no_location_reasons).forEach { reason ->
+                    Row(Modifier.padding(vertical = 3.dp)) {
+                        Icon(
+                            Icons.Outlined.FiberManualRecord,
+                            contentDescription = null,
+                            tint = cs.onSurfaceVariant.copy(alpha = 0.6f),
+                            modifier = Modifier.size(8.dp).padding(top = 6.dp),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            reason,
+                            color = cs.onSurfaceVariant,
+                            fontSize = 12.5.sp,
+                            lineHeight = 18.sp,
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider(color = cs.outlineVariant)
+        Spacer(Modifier.height(11.dp))
+
+        // 해결 안내
+        Text(
+            stringResource(R.string.no_location_solution_title),
+            color = cs.onSurface,
+            fontSize = 12.5.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            stringResource(R.string.no_location_solution_body),
+            color = cs.onSurfaceVariant,
+            fontSize = 12.5.sp,
+            lineHeight = 20.sp,
+        )
+
+        Spacer(Modifier.height(14.dp))
+
+        // 액션 버튼
+        OutlinedButton(
+            onClick = onOpenCameraSettings,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = 10.dp),
+        ) {
+            Icon(Icons.Outlined.Settings, null, Modifier.size(16.dp))
+            Spacer(Modifier.width(5.dp))
+            Text(stringResource(R.string.no_location_action_camera_settings), fontSize = 13.sp)
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun NoLocationInfoCardAPreview() {
+    WhereTogoTheme {
+        Surface {
+            NoLocationSection(
+                modifier = Modifier.padding(16.dp),
+                onOpenCameraSettings = {}
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerContent.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerContent.kt
@@ -1,0 +1,581 @@
+package com.wheretogo.presentation.composable.photoviewer
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.MediaStore
+import android.provider.Settings
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.LocationOff
+import androidx.compose.material.icons.outlined.Verified
+import androidx.compose.material.icons.rounded.Verified
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.naver.maps.map.MapView
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.map.CameraState
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.content.NaverMapSheet
+import com.wheretogo.presentation.composable.content.RowAdPlaceholder
+import com.wheretogo.presentation.composable.photoviewer.badge.StatusBadge
+import com.wheretogo.presentation.model.CameraOption
+import com.wheretogo.presentation.model.MapOverlay
+import com.wheretogo.presentation.model.NaverMapStyle
+import com.wheretogo.presentation.state.NaverMapState
+import com.wheretogo.presentation.state.StampProgress
+import com.wheretogo.presentation.theme.Palette
+import com.wheretogo.presentation.theme.WhereTogoTheme
+import com.wheretogo.presentation.theme.interFontFamily
+import com.wheretogo.presentation.viewmodel.MapEvent
+import kotlinx.coroutines.flow.SharedFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+sealed interface StampState {
+    data object Empty : StampState
+    data object Loading : StampState
+    data class Stamped(
+        val stampedAt: Long,
+        val thumbnail: String?,
+        val description: String?
+    ) : StampState
+}
+
+data class PhotoViewerActions(
+    val onStamp: (description: String?) -> Unit = {},
+    val onRemoveStamp: () -> Unit = {},
+    val onCameraUpdate: (CameraState) -> Unit = {}
+)
+
+@Composable
+fun PhotoViewerContent(
+    mapView: MapView? = null,
+    photo: GalleryPhoto? = null,
+    overlay: List<MapOverlay> = emptyList(),
+    event: SharedFlow<MapEvent>? = null,
+    fingerPrint: Int? = null,
+    stampProgress: StampProgress = StampProgress.Idle,
+    stampState: StampState = StampState.Empty,
+    actions: PhotoViewerActions = PhotoViewerActions(),
+) {
+    val context = LocalContext.current
+    var showStampInput by remember { mutableStateOf(false) }
+    var showRemoveSheet by remember { mutableStateOf(false) }
+    val haptic = LocalHapticFeedback.current
+
+    LaunchedEffect(stampState, stampProgress) {
+        when (stampState) {
+            is StampState.Stamped,
+            is StampState.Empty -> {
+                if (stampProgress == StampProgress.Idle) {
+                    if (showStampInput || showRemoveSheet) {
+                        haptic.performHapticFeedback(HapticFeedbackType.Confirm)
+                    }
+                    showStampInput = false
+                    showRemoveSheet = false
+                }
+            }
+
+            else -> {}
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 5.dp)
+    ) {
+        val courseId = photo?.courseId
+        val name = photo?.courseName
+        val date = photo?.exif?.dateTaken
+        val location = photo?.exif?.location
+        val address = photo?.simpleAddress()
+        val hasDate = date != null && date != 0L
+        val hasCourse = !(courseId.isNullOrBlank() || name.isNullOrBlank())
+        val hasLocation = location != null && mapView != null
+        val hasAddress = address != null
+
+        Column(
+            modifier = Modifier
+                .padding(top = 18.dp)
+                .padding(horizontal = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            // 뱃지
+            when {
+                !hasLocation -> {
+                    StatusBadge(
+                        text = stringResource(R.string.no_location_status),
+                        icon = Icons.Outlined.LocationOff,
+                    )
+                }
+
+                !hasCourse -> {
+                    StatusBadge(
+                        text = stringResource(R.string.no_match_header_label),
+                        icon = Icons.Outlined.Explore
+                    )
+                }
+            }
+
+            // 본문
+            when {
+                !hasLocation -> {
+                    NoLocationSection(
+                        onOpenCameraSettings = { openCameraAppInfo(context) }
+                    )
+                }
+
+                else -> {
+                    // 헤더
+                    when {
+                        !name.isNullOrBlank() -> {
+                            MatchHeader(
+                                name = name,
+                                address = address ?: "",
+                                stampState = stampState,
+                                onMore = { showRemoveSheet = true },
+                            )
+                        }
+
+                        !hasCourse -> {
+                            NoMatchHeader()
+                        }
+                    }
+
+                    // 지도
+                    NaverMapSheet(
+                        mapView = mapView,
+                        state = NaverMapState(initCamera = CameraOption.fromGalleryPhoto(photo)),
+                        style = NaverMapStyle.Place,
+                        overlayGroup = overlay,
+                        event = event,
+                        fingerPrint = fingerPrint,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(140.dp)
+                            .clip(RoundedCornerShape(20.dp))
+                            .shadow(
+                                elevation = 4.dp,
+                                shape = RoundedCornerShape(20.dp),
+                            ),
+                        onCameraUpdate = actions.onCameraUpdate
+                    )
+
+                    // 바디
+                    when {
+                        hasCourse -> {
+                            when (stampState) {
+                                is StampState.Empty -> EmptySection(onStamp = {
+                                    showStampInput = true
+                                })
+
+                                is StampState.Stamped -> StampedSection(state = stampState)
+                                is StampState.Loading -> RowAdPlaceholder()
+                            }
+                            if (showStampInput) {
+                                StampInputSheet(
+                                    placeName = name,
+                                    photo = photo,
+                                    isLoading = stampProgress == StampProgress.Stamping,
+                                    onConfirm = { desc ->
+                                        actions.onStamp(desc)
+                                    },
+                                    onDismiss = { showStampInput = false },
+                                )
+                            }
+                            if (showRemoveSheet) {
+                                RemoveStampSheet(
+                                    isLoading = stampProgress == StampProgress.Removing,
+                                    onConfirm = {
+                                        actions.onRemoveStamp()
+                                    },
+                                    onDismiss = { showRemoveSheet = false },
+                                )
+                            }
+                        }
+
+                        else -> {
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                if (hasDate)
+                                    DateLabel(date)
+                                if (hasAddress)
+                                    AddressLabel(address)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MatchHeader(
+    name: String,
+    address: String,
+    stampState: StampState,
+    onMore: () -> Unit = {},
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        StampBadge(stampState)
+        Spacer(Modifier.width(8.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text = address,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (stampState is StampState.Stamped) {
+            IconButton(onClick = onMore) {
+                Icon(Icons.Default.MoreVert, null)
+            }
+        }
+    }
+}
+
+private fun millisToDate(millis: Long): String {
+    val sdf = SimpleDateFormat("yyyy.MM.dd")
+    return sdf.format(Date(millis))
+}
+
+@Composable
+fun NoMatchHeader(
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column {
+            Text(
+                text = stringResource(R.string.no_match_header_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                lineHeight = 24.sp
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.no_match_header_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineHeight = 18.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun StampBadge(stampState: StampState) {
+    val stamped = stampState is StampState.Stamped
+    Box(
+        modifier = Modifier
+            .then(
+                if (stamped) Modifier.background(
+                    MaterialTheme.colorScheme.primaryContainer, CircleShape
+                ) else Modifier
+            ),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Verified,
+            contentDescription = null,
+            tint = if (stamped) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            modifier = Modifier.size(42.dp)
+        )
+    }
+}
+
+@Composable
+private fun EmptySection(
+    onStamp: () -> Unit,
+) {
+    Column {
+        Text(
+            text = stringResource(R.string.swipe_to_pick_photo),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp)
+        )
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = onStamp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Icon(Icons.Outlined.Verified, contentDescription = null)
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = stringResource(R.string.pick_this_photo),
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun DateLabel(ts: Long) {
+    Row(
+        modifier = Modifier.padding(horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(Icons.Default.DateRange, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.KOREA).format(Date(ts)),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}
+
+@Composable
+private fun AddressLabel(address: String) {
+    Row(
+        modifier = Modifier.padding(horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(Icons.Default.Map, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = address,
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}
+
+@Composable
+private fun StampedSection(
+    state: StampState.Stamped
+) {
+    val isPreview = LocalInspectionMode.current
+    if (state.thumbnail.isNullOrBlank()) return
+
+    val surfaceColor = Color(0xFFF7F5F0)
+    val accentColor = Palette.MutedBlue
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 8.dp,
+                shape = RoundedCornerShape(20.dp),
+                spotColor = accentColor.copy(alpha = 0.15f),
+            )
+            .clip(RoundedCornerShape(20.dp))
+            .background(surfaceColor)          // 배경은 크림
+            .padding(12.dp)                    // border 제거
+    ) {
+        if (isPreview) {
+            Box(
+                Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(accentColor.copy(alpha = 0.15f))
+            )
+        } else {
+            AsyncImage(
+                model = state.thumbnail,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(14.dp))
+            )
+        }
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.weight(1f)
+        ) {
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Rounded.Verified,
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.size(14.dp)
+                )
+                Text(
+                    stringResource(
+                        R.string.num_visit,
+                        millisToDate(state.stampedAt)
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = accentColor,
+                )
+            }
+
+            if (!state.description.isNullOrBlank()) {
+                Text(
+                    state.description,
+                    style = TextStyle(
+                        fontFamily = interFontFamily,
+                        fontSize = 14.sp,
+                        lineHeight = 20.sp,
+                        color = Palette.Black50
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun MatchHeaderPreview() {
+    WhereTogoTheme {
+        Column {
+            MatchHeader(
+                name = "더 현대 야경길",
+                address = "대한민국 서울특별시",
+                stampState = StampState.Empty,
+                {}
+            )
+            MatchHeader(
+                name = "더 현대 야경길",
+                address = "대한민국 서울특별시",
+                stampState =
+                    StampState.Stamped(
+                        0,
+                        null,
+                        ""
+                    ),
+                {}
+            )
+        }
+
+    }
+}
+
+@Composable
+@Preview
+private fun NoMatchHeaderPreview() {
+    WhereTogoTheme {
+        NoMatchHeader(modifier = Modifier.padding(16.dp))
+    }
+}
+
+@Composable
+@Preview
+private fun LabelPreview() {
+    WhereTogoTheme {
+        Column {
+            DateLabel(0L)
+            AddressLabel("서울시 중구 231-3")
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun EmptySectionPreview() {
+    WhereTogoTheme {
+        EmptySection({})
+    }
+}
+
+@Composable
+@Preview
+private fun StampedSelectionPreview() {
+    WhereTogoTheme {
+        Column {
+            StampedSection(
+                StampState.Stamped(
+                    stampedAt = 0L,
+                    thumbnail = "preview",
+                    description = "좋았던 곳. 다시 방문하고 싶어요, 최고의 사진이에요."
+                )
+            )
+        }
+
+    }
+}
+
+fun openCameraAppInfo(context: Context) {
+    val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+    val resolveInfo = context.packageManager.resolveActivity(
+        cameraIntent,
+        PackageManager.MATCH_DEFAULT_ONLY
+    )
+    val packageName = resolveInfo?.activityInfo?.packageName
+
+    if (packageName != null && packageName != "android") {
+        val settingsIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.parse("package:$packageName")
+        }
+        context.startActivity(settingsIntent)
+    } else {
+        Toast.makeText(context, "기본 카메라 앱을 찾을 수 없습니다", Toast.LENGTH_SHORT).show()
+    }
+}
+
+
+

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerScreen.kt
@@ -1,44 +1,49 @@
-package com.wheretogo.presentation.composable.gallery
+package com.wheretogo.presentation.composable.photoviewer
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -50,39 +55,60 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
+import com.naver.maps.map.MapView
 import com.wheretogo.domain.model.gallery.GalleryPhoto
 import com.wheretogo.domain.model.gallery.PhotoExif
-import com.wheretogo.presentation.R
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.wheretogo.presentation.composable.effect.LifecycleDisposer
+import com.wheretogo.presentation.intent.PhotoViewerIntent
+import com.wheretogo.presentation.theme.Palette
+import com.wheretogo.presentation.viewmodel.PhotoViewerViewModel
 
-
-@OptIn(ExperimentalSharedTransitionApi::class)
+@OptIn(ExperimentalSharedTransitionApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun PhotoViewerScreen(
-    photo: GalleryPhoto,
+    photos: List<GalleryPhoto>,
+    initialIndex: Int,
     sharedScope: SharedTransitionScope,
     animatedScope: AnimatedVisibilityScope,
-    onClose: () -> Unit,
-    settingsContent: @Composable (GalleryPhoto) -> Unit = { DefaultPhotoSettings(it) },
+    mapView: MapView?,
+    viewModel: PhotoViewerViewModel = hiltViewModel(),
+    onClose: () -> Unit = {},
 ) {
+    val state by viewModel.state.collectAsState()
     val density = LocalDensity.current
     val window = LocalWindowInfo.current
-    val photoHeightIn = calculateHeightIn(window,photo.exif)
-    val heightInScrollState = remember(photoHeightIn.max) { HeightInScrollState(photoHeightIn) }
+
+    val pagerState = rememberPagerState(
+        initialPage = initialIndex,
+        pageCount = { photos.size },
+    )
+    val currentPhoto = photos[pagerState.currentPage]
+
+    val photoHeightIn = calculateHeightIn(window, currentPhoto.exif)
+    val heightInScrollState = remember(photoHeightIn.max) {
+        HeightInScrollState(photoHeightIn)
+    }
     val photoHeight by animateFloatAsState(
         targetValue = heightInScrollState.targetHeight,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessLow),
+        animationSpec =
+            spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessLow),
         label = "photoHeight",
     )
+    val fingerPrint by viewModel.fingerPrint.collectAsState()
 
     BackHandler { onClose() }
+
+    LaunchedEffect(pagerState.currentPage) {
+        viewModel.handleIntent(PhotoViewerIntent.Refresh(currentPhoto))
+    }
+
+    LifecycleDisposer {
+        viewModel.handleIntent(PhotoViewerIntent.LifecycleChange(it))
+    }
 
     Box(
         Modifier
@@ -96,32 +122,84 @@ fun PhotoViewerScreen(
                     .fillMaxWidth()
                     .height(with(density) { photoHeight.toDp() })
                     .clipToBounds(),
-                contentAlignment = Alignment.Center,
             ) {
-                with(sharedScope) {
-                    AsyncImage(
-                        model = photo.uriString,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize(),
+                ) { page ->
+                    val pagePhoto = photos[page]
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        val imageModifier = if (page == initialIndex) {
+                            with(sharedScope) {
+                                Modifier
+                                    .fillMaxSize()
+                                    .sharedElement(
+                                        sharedContentState =
+                                            rememberSharedContentState(key = pagePhoto.id),
+                                        animatedVisibilityScope = animatedScope,
+                                    )
+                            }
+                        } else {
+                            Modifier.fillMaxSize()
+                        }
+                        if(pagePhoto.imageSource==null)
+                            AsyncImage(
+                                model = pagePhoto.thumbnail,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = imageModifier,
+                            )
+                        AsyncImage(
+                            model = pagePhoto.imageSource,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = imageModifier,
+                        )
+                    }
+                }
+
+                if (photos.size > 1) {
+                    PageIndicator(
+                        pageCount = photos.size,
+                        currentPage = pagerState.currentPage,
                         modifier = Modifier
-                            .fillMaxSize()
-                            .sharedElement(
-                                rememberSharedContentState(key = photo.id),
-                                animatedVisibilityScope = animatedScope,
-                            ),
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 12.dp),
                     )
                 }
             }
 
+
             Surface(
-                color = MaterialTheme.colorScheme.surface,
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
                     .verticalScroll(rememberScrollState()),
             ) {
                 Box(modifier = Modifier.boundedHeight()) {
-                    settingsContent(photo)
+                    PhotoViewerContent(
+                        mapView = mapView,
+                        photo = currentPhoto,
+                        overlay = viewModel.overlay,
+                        fingerPrint = fingerPrint,
+                        event = viewModel.event,
+                        stampState = state.stampState,
+                        stampProgress = state.stampProgress,
+                        actions = PhotoViewerActions(
+                            onStamp = {
+                                viewModel.handleIntent(PhotoViewerIntent.Stamp(currentPhoto,it))
+                            },
+                            onRemoveStamp = {
+                                viewModel.handleIntent(PhotoViewerIntent.RemoveStamp(currentPhoto))
+                            },
+                            onCameraUpdate = {
+                                viewModel.handleIntent(PhotoViewerIntent.CameraUpdate(it))
+                            }
+                        ),
+                    )
                 }
             }
         }
@@ -133,12 +211,42 @@ fun PhotoViewerScreen(
                 .padding(8.dp)
                 .align(Alignment.TopStart),
         ) {
-            Icon(Icons.Default.Close, contentDescription = "닫기", tint = Color.White)
+            Icon(Icons.Default.Close, null, tint = Color.White)
         }
     }
 }
 
-fun Modifier.boundedHeight(): Modifier = layout { measurable, constraints ->
+@Composable
+private fun PageIndicator(
+    pageCount: Int,
+    currentPage: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(pageCount) { i ->
+            val isCurrent = i == currentPage
+            val width by animateDpAsState(
+                targetValue = if (isCurrent) 18.dp else 6.dp,
+                animationSpec = tween(durationMillis = 250),
+                label = "dot_width"
+            )
+            Box(
+                modifier = Modifier
+                    .height(6.dp)
+                    .width(width)
+                    .clip(if (isCurrent) RoundedCornerShape(3.dp) else CircleShape)
+                    .background(Palette.White)
+                ,
+            )
+        }
+    }
+}
+
+private fun Modifier.boundedHeight(): Modifier = layout { measurable, constraints ->
     val safe = if (constraints.maxHeight == Constraints.Infinity) {
         val maxH = Constraints.fitPrioritizingWidth(
             minWidth = constraints.minWidth,
@@ -182,40 +290,6 @@ private class HeightInScrollState(
         val consumedHeight = resizeHeight - targetHeight
         targetHeight = resizeHeight
         return consumedHeight / followRatio  // 원본 단위로 환산
-    }
-}
-
-@Composable
-private fun DefaultPhotoSettings(photo: GalleryPhoto) {
-    Column(
-        Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Text(stringResource(R.string.detail_info), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-
-        photo.exif.dateTaken?.let { ts ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.KOREA).format(Date(ts)),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-        }
-
-        photo.exif.location?.let { loc ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    "%.4f, %.4f".format(loc.latitude, loc.longitude),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-        }
     }
 }
 

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/RemoveStampSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/RemoveStampSheet.kt
@@ -1,0 +1,93 @@
+package com.wheretogo.presentation.composable.photoviewer
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.animation.rememberDelayedState
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RemoveStampSheet(
+    isLoading: Boolean = false,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val delayLoading = rememberDelayedState(isLoading, delayMillis = 100L)
+    ModalBottomSheet(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 16.dp),
+        ) {
+            Text(
+                stringResource(R.string.confirm_unstamp),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.record_removed_from_course),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineHeight = 20.sp,
+            )
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { if (!isLoading) onConfirm() },
+                enabled = !delayLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                if (delayLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                } else {
+                    Text(stringResource(R.string.unstamp), fontWeight = FontWeight.Medium)
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            TextButton(
+                onClick = { if (!isLoading) onDismiss() },
+                enabled = !delayLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/StampInputSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/StampInputSheet.kt
@@ -1,0 +1,124 @@
+package com.wheretogo.presentation.composable.photoviewer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Verified
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.presentation.R
+import com.wheretogo.presentation.composable.animation.rememberDelayedState
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StampInputSheet(
+    placeName: String,
+    photo: GalleryPhoto?,
+    isLoading: Boolean,
+    onConfirm: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    val maxLen = 100
+    val delayLoading = rememberDelayedState(isLoading, delayMillis = 100L)
+    ModalBottomSheet(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 16.dp)
+                .imePadding(),
+        ) {
+            Text(
+                placeName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                AsyncImage(
+                    model = photo?.imageSource,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                )
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { if (it.length <= maxLen) text = it },
+                    placeholder = { Text(stringResource(R.string.write_record_here)) },
+                    enabled = !delayLoading,
+                    modifier = Modifier
+                        .weight(1f)
+                        .heightIn(min = 64.dp),
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "${text.length} / $maxLen",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.End),
+            )
+
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = { if (!isLoading) onConfirm(text.ifBlank { null }) },
+                enabled = !delayLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                if (delayLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Icon(Icons.Outlined.Verified, contentDescription = null)
+                    Spacer(Modifier.width(6.dp))
+                    Text(stringResource(R.string.stamp_down), fontWeight = FontWeight.Medium)
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/badge/StatusBadge.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/badge/StatusBadge.kt
@@ -1,0 +1,53 @@
+package com.wheretogo.presentation.composable.photoviewer.badge
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wheretogo.presentation.theme.Palette
+import com.wheretogo.presentation.theme.WhereTogoTheme
+
+@Composable
+fun StatusBadge(text: String, icon: ImageVector) {
+    val warning = Palette.Warning.tint
+    Surface(
+        color = Palette.Warning.container,
+        shape = RoundedCornerShape(6.dp),
+    ) {
+        Row(
+            Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, null, tint = warning, modifier = Modifier.
+            size(14.dp))
+            Spacer(Modifier.width(5.dp))
+            Text(text, color = warning, fontSize = 12.sp)
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun Preview(){
+    WhereTogoTheme {
+        StatusBadge(
+            "위치 정보 없음",
+            icon = Icons.Outlined.Explore
+        )
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/di/StateModule.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/di/StateModule.kt
@@ -38,18 +38,13 @@ class StateModule {
         buildConfig: PresentationBuildConfig
     ): CourseAddScreenState {
         return CourseAddScreenState(
-            naverMapState = NaverMapState(isZoomControl = buildConfig.isTestUi),
             isTestUi = buildConfig.isTestUi
         )
     }
 
     @Singleton
     @Provides
-    fun provideMapState(
-        buildConfig: PresentationBuildConfig
-    ): MapState {
-        return MapState(
-            naverMapState = NaverMapState(isZoomControl = buildConfig.isTestUi),
-        )
+    fun provideMapState(): MapState {
+        return MapState()
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
@@ -50,3 +50,30 @@ class ByDayGrouping : GroupingStrategy {
         val titleFormat = SimpleDateFormat("yyyy년 M월 d일", Locale.KOREA)
     }
 }
+
+class ByCourseGrouping : GroupingStrategy {
+
+    override val label: String = "코스별"
+
+    override val comparator: Comparator<GalleryPhoto> =
+        compareByDescending<GalleryPhoto> { it.courseId != null && it.courseName != null }
+            .thenBy {
+                when (it.courseName) {
+                    null, KEY_UNKNOWN -> 2
+                    else -> 0
+                }
+            }.thenBy { it.courseName ?: KEY_UNKNOWN }
+            .thenByDescending { it.exif.dateTaken ?: Long.MIN_VALUE }
+
+    override fun keyOf(photo: GalleryPhoto): String = photo.courseName ?: KEY_UNKNOWN
+
+    override fun titleOf(key: String, sample: GalleryPhoto): String =
+        when (key) {
+            KEY_UNKNOWN -> "미확인"
+            else -> key
+        }
+
+    private companion object {
+        const val KEY_UNKNOWN = ""
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/Grouping.kt
@@ -24,7 +24,12 @@ fun List<GalleryPhoto>.toSections(strategy: GroupingStrategy): List<PhotoSection
     this.sortedWith(strategy.comparator)
         .groupBy { strategy.keyOf(it) }
         .map { (key, photos) ->
-            PhotoSection(key = key, title = strategy.titleOf(key, photos.first()), photos = photos)
+            PhotoSection(
+                key = key,
+                title = strategy.titleOf(key, photos.first()),
+                hasStamp = photos.any{it.isStampedGroup?:false},
+                photos = photos
+            )
         }
 
 class ByDayGrouping : GroupingStrategy {

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/map/MapOverlayService.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/map/MapOverlayService.kt
@@ -68,4 +68,12 @@ interface MapOverlayService {
 
     fun createFullPath(points: List<LatLng> = emptyList()): Result<Unit>
 
+
+    //================================
+
+    fun refreshSpot(latLng: LatLng)
+
+    fun refreshPath(course: Course)
+
+
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/feature/map/MapOverlayServiceImpl.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/feature/map/MapOverlayServiceImpl.kt
@@ -364,4 +364,44 @@ class MapOverlayServiceImpl @Inject constructor(
         }.map { }
     }
 
+
+    //======================================
+
+    override fun refreshSpot(latLng: LatLng) {
+        val id = "SIMPLE_SPOT"
+        val spotKey = oneTimeMarkerKey(id)
+        if (overlayProvider.overlays.none { it.key == spotKey.value }) {
+            overlayProvider.addMarker(
+                key = spotKey,
+                info = MarkerInfo(
+                    contentId = id,
+                    position = latLng,
+                    iconRes = R.drawable.ic_mk_df
+                )
+            )
+        } else {
+            overlayProvider.updateMarkerPosition(spotKey, latLng)
+        }
+    }
+
+    override fun refreshPath(
+        course: Course,
+    ) = updateScope {
+        val pathKey = coursePathKey(course.courseId)
+        var path: MapOverlay? = null
+        val remove = buildList {
+            overlayProvider.overlays.forEach {
+                if (it.type == OverlayType.FULL_PATH)
+                    when (it.key) {
+                        pathKey.value -> path = it
+                        else -> add(StringKey(it.key))
+                    }
+            }
+        }
+
+        if (path == null)
+            overlayProvider.addPath(pathKey, course.toPathInfo())
+
+        overlayProvider.removeOverlay(remove)
+    }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/intent/PhotoViewerIntent.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/intent/PhotoViewerIntent.kt
@@ -1,0 +1,16 @@
+package com.wheretogo.presentation.intent
+
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.model.map.CameraState
+import com.wheretogo.presentation.AppLifecycle
+
+sealed class PhotoViewerIntent {
+
+    data class Refresh(val photo: GalleryPhoto) : PhotoViewerIntent()
+    data class Stamp(val photo: GalleryPhoto, val description: String?) : PhotoViewerIntent()
+    data class RemoveStamp(val photo: GalleryPhoto) : PhotoViewerIntent()
+    data class CameraUpdate(val camera: CameraState) : PhotoViewerIntent()
+
+    //공통
+    data class LifecycleChange(val event: AppLifecycle) : PhotoViewerIntent()
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/model/CameraOption.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/CameraOption.kt
@@ -3,6 +3,7 @@ package com.wheretogo.presentation.model
 import com.wheretogo.domain.ZOOM
 import com.wheretogo.domain.model.address.LatLng
 import com.wheretogo.domain.model.course.Course
+import com.wheretogo.domain.model.gallery.GalleryPhoto
 import com.wheretogo.domain.model.map.CameraMoveTrigger
 import com.wheretogo.domain.model.map.MoveAnimation
 
@@ -18,6 +19,18 @@ data class CameraOption(
         fun fromCourse(course: Course): CameraOption {
             return CameraOption(
                 latLng = course.cameraLatLng,
+                zoom = ZOOM.Place.level,
+                updateSource = CameraMoveTrigger.DEFAULT,
+                moveAnimation = MoveAnimation.APP_JUMP,
+                isMyLocation = false
+            )
+        }
+
+        fun fromGalleryPhoto(photo: GalleryPhoto): CameraOption? {
+            val latLng = photo.exif.location
+            return if (latLng == null) null
+            else CameraOption(
+                latLng = latLng,
                 zoom = ZOOM.Place.level,
                 updateSource = CameraMoveTrigger.DEFAULT,
                 moveAnimation = MoveAnimation.APP_JUMP,

--- a/presentation/src/main/java/com/wheretogo/presentation/model/CameraOption.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/CameraOption.kt
@@ -1,6 +1,8 @@
 package com.wheretogo.presentation.model
 
+import com.wheretogo.domain.ZOOM
 import com.wheretogo.domain.model.address.LatLng
+import com.wheretogo.domain.model.course.Course
 import com.wheretogo.domain.model.map.CameraMoveTrigger
 import com.wheretogo.domain.model.map.MoveAnimation
 
@@ -10,4 +12,17 @@ data class CameraOption(
     val updateSource: CameraMoveTrigger,
     val moveAnimation: MoveAnimation,
     val isMyLocation: Boolean = false
-)
+) {
+
+    companion object {
+        fun fromCourse(course: Course): CameraOption {
+            return CameraOption(
+                latLng = course.cameraLatLng,
+                zoom = ZOOM.Place.level,
+                updateSource = CameraMoveTrigger.DEFAULT,
+                moveAnimation = MoveAnimation.APP_JUMP,
+                isMyLocation = false
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/model/NaverMapStyle.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/NaverMapStyle.kt
@@ -54,7 +54,9 @@ data class NaverMapStyle(
             locationButtonEnabled = true
         )
 
-        val Place = NaverMapStyle()
+        val Place = NaverMapStyle(
+            symbolScale = 1f
+        )
     }
 }
 

--- a/presentation/src/main/java/com/wheretogo/presentation/model/NaverMapStyle.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/NaverMapStyle.kt
@@ -1,0 +1,61 @@
+package com.wheretogo.presentation.model
+
+import com.naver.maps.map.NaverMap
+import com.wheretogo.domain.ZOOM
+
+data class NaverMapStyle(
+    // 지도 종류
+    val mapType: NaverMap.MapType = NaverMap.MapType.Basic,
+
+    // 줌
+    val maxZoom: Double = ZOOM.Place.level,
+    val minZoom: Double = ZOOM.COUNTRY.level,
+
+    // 레이어 그룹 on/off
+    val buildingEnabled: Boolean = false,
+    val transitEnabled: Boolean = false,
+    val bicycleEnabled: Boolean = false,
+    val trafficEnabled: Boolean = false,
+    val cadastralEnabled: Boolean = false,
+    val mountainEnabled: Boolean = false,
+
+    // POI 심볼
+    val symbolScale: Float = 0f,
+    val symbolPerspectiveRatio: Float = 0f,
+
+    // 모드
+    val indoorEnabled: Boolean = false,
+    val nightModeEnabled: Boolean = false,
+
+    // 제스처
+    val scrollGesturesEnabled: Boolean = false,
+    val zoomGesturesEnabled: Boolean = false,
+    val tiltGesturesEnabled: Boolean = false,
+    val rotateGesturesEnabled: Boolean = false,
+
+    // UI 컨트롤
+    val zoomControlEnabled: Boolean = false,
+    val compassEnabled: Boolean = false,
+    val scaleBarEnabled: Boolean = false,
+    val locationButtonEnabled: Boolean = false,
+    val logoClickEnabled: Boolean = false,
+
+) {
+    companion object {
+        val Basic = NaverMapStyle(
+            symbolScale = 1f,
+            symbolPerspectiveRatio = 1f,
+            scrollGesturesEnabled = true,
+            zoomGesturesEnabled = true,
+            tiltGesturesEnabled = true,
+            rotateGesturesEnabled = true,
+            compassEnabled = true,
+            scaleBarEnabled = true,
+            locationButtonEnabled = true
+        )
+
+        val Place = NaverMapStyle()
+    }
+}
+
+

--- a/presentation/src/main/java/com/wheretogo/presentation/model/PhotoSection.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/model/PhotoSection.kt
@@ -5,5 +5,6 @@ import com.wheretogo.domain.model.gallery.GalleryPhoto
 data class PhotoSection(
     val key: String,
     val title: String,
+    val hasStamp: Boolean,
     val photos: List<GalleryPhoto>,
 )

--- a/presentation/src/main/java/com/wheretogo/presentation/state/GalleryState.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/state/GalleryState.kt
@@ -13,6 +13,7 @@ sealed interface GalleryState {
         val isSelectionMode: Boolean get() = selectedIds.isNotEmpty()
         val allPhotos: List<GalleryPhoto> get() = sections.flatMap { it.photos }
     }
+    data object Empty : GalleryState
     data class Error(val message: String) : GalleryState
 
     suspend fun<T> onSuccessAwait(callback: suspend (Success)-> T): T?{

--- a/presentation/src/main/java/com/wheretogo/presentation/state/NaverMapState.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/state/NaverMapState.kt
@@ -5,6 +5,5 @@ import com.wheretogo.presentation.model.CameraOption
 
 data class NaverMapState(
     val latestCameraState: CameraState = CameraState(),
-    val initCamera: CameraOption? = null,
-    val isZoomControl: Boolean = false,
+    val initCamera: CameraOption? = null
 )

--- a/presentation/src/main/java/com/wheretogo/presentation/state/NaverMapState.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/state/NaverMapState.kt
@@ -1,8 +1,10 @@
 package com.wheretogo.presentation.state
 
 import com.wheretogo.domain.model.map.CameraState
+import com.wheretogo.presentation.model.CameraOption
 
 data class NaverMapState(
     val latestCameraState: CameraState = CameraState(),
-    val isZoomControl: Boolean = false
+    val initCamera: CameraOption? = null,
+    val isZoomControl: Boolean = false,
 )

--- a/presentation/src/main/java/com/wheretogo/presentation/state/PhotoViewerState.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/state/PhotoViewerState.kt
@@ -1,0 +1,10 @@
+package com.wheretogo.presentation.state
+
+import com.wheretogo.presentation.composable.photoviewer.StampState
+
+enum class StampProgress { Idle, Stamping, Removing }
+
+data class PhotoViewerState(
+    val stampState: StampState = StampState.Empty,
+    val stampProgress: StampProgress = StampProgress.Idle
+)

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
@@ -1,8 +1,13 @@
 package com.wheretogo.presentation.theme
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 
-
+@Immutable
+data class ExtendedColors(
+    val tint: Color,
+    val container: Color,
+)
 object Palette {
 
     // Brand / Blue
@@ -14,7 +19,9 @@ object Palette {
     val Blue400 = Color(0xFF0046A7)
     val Blue500 = Color(0xFF182A56)
     val Blue600 = Color(0xFF214876)
+
     val PrimeBlue = Color(0xFF509BDC)
+    val MutedBlue = Color(0xFF3A6EA5)
 
     // Purple / Pink
     val Purple200 = Color(0xFFBB86FC)
@@ -27,6 +34,12 @@ object Palette {
     // Green
     val Green50 = Color(0xFFCCE8CC)
     val Green100 = Color(0xFFB9D7B9)
+
+    // Wood
+    val Warning = ExtendedColors(
+        tint =  Color(0xFF633806),
+        container = Color(0xFFFAEEDA)
+    )
 
     // Neutral - White
     val White = Color(0xFFFFFFFF)
@@ -45,5 +58,6 @@ object Palette {
 
     // Neutral - Black
     val Black = Color(0xFF000000)
+    val Black50 = Color(0xFF2A2A28)
     val Black100 = Color(0xFF202020)
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Theme.kt
@@ -21,6 +21,9 @@ private val LightColorScheme = lightColorScheme(
     onSecondaryContainer = Palette.Blue600,
     surface = Palette.White50,
     surfaceContainerLow = Palette.White100,
+    surfaceContainerHigh = Palette.Gray50,
+    onSurface = Palette.Black100,
+    onSurfaceVariant = Palette.Gray300,
     background = Palette.White100
 )
 

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Type.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Type.kt
@@ -1,6 +1,7 @@
 package com.wheretogo.presentation.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -39,20 +40,4 @@ val Typography = Typography(
         letterSpacing = 0.5.sp
     )
 
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-    */
 )

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
@@ -9,6 +9,7 @@ import com.wheretogo.domain.usecase.gallery.DeleteGalleryPhotosUseCase
 import com.wheretogo.domain.usecase.gallery.LoadGalleryPhotosUseCase
 import com.wheretogo.domain.usecase.gallery.SavePickedImagesUseCase
 import com.wheretogo.presentation.MainDispatcher
+import com.wheretogo.presentation.feature.ByCourseGrouping
 import com.wheretogo.presentation.feature.ByDayGrouping
 import com.wheretogo.presentation.feature.GroupingStrategy
 import com.wheretogo.presentation.feature.toSections
@@ -52,7 +53,7 @@ class GalleryFlowViewModel @Inject constructor(
     private val _effect = MutableSharedFlow<GalleryUiEffect>()
     val effect: SharedFlow<GalleryUiEffect> = _effect.asSharedFlow()
 
-    val groupings: List<GroupingStrategy> = listOf(ByDayGrouping())
+    val groupings: List<GroupingStrategy> = listOf(ByCourseGrouping(),ByDayGrouping())
     private var _grouping: GroupingStrategy = groupings.first()
     val currentGroupingLabel: String get() = _grouping.label
 

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
@@ -27,7 +27,11 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -38,13 +42,15 @@ sealed interface GalleryUiEffect {
     data class NavigateToDetail(val photoId: Long) : GalleryUiEffect
 }
 
+data class GroupPhoto(val photos: List<GalleryPhoto>, val selectedIndex: Int)
+
 @HiltViewModel
 class GalleryFlowViewModel @Inject constructor(
     @MainDispatcher private val dispatcher: CoroutineDispatcher,
     private val handler: GalleryFlowHandler,
     private val savePickedImagesUseCase: SavePickedImagesUseCase,
-    private val loadGalleryPhotos: LoadGalleryPhotosUseCase,
-    private val deleteGalleryPhotos: DeleteGalleryPhotosUseCase,
+    private val loadGalleryPhotosUseCase: LoadGalleryPhotosUseCase,
+    private val deleteGalleryPhotosUseCase: DeleteGalleryPhotosUseCase,
 ) : ViewModel() {
     private val _galleyState =
         MutableStateFlow<GalleryState>(GalleryState.Loading)
@@ -53,24 +59,42 @@ class GalleryFlowViewModel @Inject constructor(
     private val _effect = MutableSharedFlow<GalleryUiEffect>()
     val effect: SharedFlow<GalleryUiEffect> = _effect.asSharedFlow()
 
-    val groupings: List<GroupingStrategy> = listOf(ByCourseGrouping(),ByDayGrouping())
+    val groupings: List<GroupingStrategy> = listOf(ByCourseGrouping(), ByDayGrouping())
     private var _grouping: GroupingStrategy = groupings.first()
     val currentGroupingLabel: String get() = _grouping.label
 
     private var _cachedPhotos: List<GalleryPhoto> = emptyList()
     private val _detailPhotoId = MutableStateFlow<Long?>(null)
-    val detailPhoto: StateFlow<GalleryPhoto?> = _detailPhotoId
-        .map { id -> id?.let { selectedId -> _cachedPhotos.firstOrNull { it.id == selectedId } } }
+
+    val groupPhoto: StateFlow<GroupPhoto?> = _detailPhotoId
+        .map { id ->
+            val select = id?.let { selectedId -> _cachedPhotos.firstOrNull { it.id == selectedId } } ?: return@map null
+            if(select.courseId.isNullOrBlank()){
+                return@map GroupPhoto(listOf(select),0)
+            }
+            val group = _cachedPhotos.filter { it.courseId == select.courseId }
+            val index = group.indexOfFirst { it.id == select.id }.coerceAtLeast(0)
+            GroupPhoto(group, index)
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     init {
-        initSuccess()
-        viewModelScope.launch(dispatcher) {
-            withContext(Dispatchers.IO){
-                delay(350)
-                handleIntent(GalleryIntent.Refresh)
+        observeGalleryPhotos()
+    }
+
+    private fun observeGalleryPhotos() {
+        loadGalleryPhotosUseCase.observe()
+            .onStart { delay(310) } // 화면 이동 대기
+            .onEach { photos ->
+                _cachedPhotos = photos
+                val selected = (_galleyState.value as? GalleryState.Success)?.selectedIds ?: emptySet()
+                if(photos.isEmpty())
+                    initEmpty()
+                else
+                    initSuccess(selectedIds = selected)
             }
-        }
+            .flowOn(Dispatchers.IO)
+            .launchIn(viewModelScope)
     }
 
     fun handleIntent(intent: GalleryIntent) {
@@ -96,7 +120,6 @@ class GalleryFlowViewModel @Inject constructor(
         handler.handle(e,event)
     }
 
-    // 갤러리 갱신
     private suspend fun onMediaPicked(images: List<PickerImage>) {
         if (images.isEmpty()) return
         _galleyState.value = GalleryState.Loading
@@ -108,18 +131,13 @@ class GalleryFlowViewModel @Inject constructor(
     }
 
     private suspend fun refreshGallery() {
-        withContext(Dispatchers.IO) { loadGalleryPhotos() }
-            .onSuccess { photos ->
-                _cachedPhotos = photos
-                initSuccess()
-            }.onFailure {
+        withContext(Dispatchers.IO) { loadGalleryPhotosUseCase.groupRefresh() }
+            .onFailure {
                 _galleyState.value = GalleryState.Error("")
                 handleError(it, GalleryFlowMsgEvent.GALLERY_LOAD_FAIL)
             }
     }
 
-
-    // 갤러리 로드 성공시
     private fun changeGrouping(strategy: GroupingStrategy) {
         if (strategy.label == _grouping.label) return
         _galleyState.value.onSuccess {
@@ -128,12 +146,12 @@ class GalleryFlowViewModel @Inject constructor(
         }
     }
 
-    private suspend fun onPhotoClick(pickerId: Long) {
+    private suspend fun onPhotoClick(photoId: Long) {
         _galleyState.value.onSuccessAwait {
             if (it.isSelectionMode) {
-                it.toggleSelection(pickerId)
+                it.toggleSelection(photoId)
             } else {
-                _effect.emit(GalleryUiEffect.NavigateToDetail(pickerId))
+                _effect.emit(GalleryUiEffect.NavigateToDetail(photoId))
             }
         }
     }
@@ -160,12 +178,9 @@ class GalleryFlowViewModel @Inject constructor(
         _galleyState.value.onSuccessAwait {
             val targets = it.selectedIds
             if (targets.isEmpty()) return@onSuccessAwait
-            withContext(Dispatchers.IO) { deleteGalleryPhotos(targets) }
-                .onSuccess { deletedIds ->
-                    _cachedPhotos = _cachedPhotos.filterNot { it.id in deletedIds }
-                    initSuccess()
-                }.onFailure {
-                    handleError(it, GalleryFlowMsgEvent.PHOTO_DELETE_FAIL)
+            withContext(Dispatchers.IO) { deleteGalleryPhotosUseCase(targets) }
+                .onFailure { e ->
+                    handleError(e, GalleryFlowMsgEvent.PHOTO_DELETE_FAIL)
                 }
         }
     }
@@ -190,6 +205,10 @@ class GalleryFlowViewModel @Inject constructor(
             selectedIds = validSelected,
             groupingLabel = _grouping.label,
         )
+    }
+
+    private fun initEmpty(){
+        _galleyState.value = GalleryState.Empty
     }
 
     private fun GalleryState.Success.toggleSelection(id: Long) {

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MapViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/MapViewModel.kt
@@ -47,7 +47,7 @@ import javax.inject.Inject
 
 
 sealed class MapEvent{
-    data class MoveCamera(val cameraState: CameraOption):MapEvent()
+    data class MoveCamera(val option: CameraOption):MapEvent()
 }
 
 @HiltViewModel

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/PhotoViewerViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/PhotoViewerViewModel.kt
@@ -1,0 +1,190 @@
+package com.wheretogo.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wheretogo.domain.ZOOM
+import com.wheretogo.domain.feature.LocationService
+import com.wheretogo.domain.handler.ErrorHandler
+import com.wheretogo.domain.model.checkpoint.CheckPointContent
+import com.wheretogo.domain.model.gallery.GalleryPhoto
+import com.wheretogo.domain.usecase.checkpoint.AddCheckpointToCourseUseCase
+import com.wheretogo.domain.usecase.checkpoint.RemoveCheckPointUseCase
+import com.wheretogo.domain.usecase.course.GetCourseUseCase
+import com.wheretogo.domain.usecase.gallery.GetStampUseCase
+import com.wheretogo.domain.model.gallery.Stamp
+import com.wheretogo.domain.model.map.CameraState
+import com.wheretogo.domain.model.map.MoveAnimation
+import com.wheretogo.presentation.AppLifecycle
+import com.wheretogo.presentation.MainDispatcher
+import com.wheretogo.presentation.composable.photoviewer.StampState
+import com.wheretogo.presentation.feature.map.MapOverlayService
+import com.wheretogo.presentation.intent.PhotoViewerIntent
+import com.wheretogo.presentation.model.CameraOption
+import com.wheretogo.presentation.state.PhotoViewerState
+import com.wheretogo.presentation.state.StampProgress
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+
+
+@HiltViewModel
+class PhotoViewerViewModel @Inject constructor(
+    @MainDispatcher private val dispatcher: CoroutineDispatcher,
+    private val handler: ErrorHandler,
+    private val getCourseUseCase: GetCourseUseCase,
+    private val getStampUseCase: GetStampUseCase,
+    private val addCheckpointToCourseUseCase: AddCheckpointToCourseUseCase,
+    private val removeCheckPointUseCase: RemoveCheckPointUseCase,
+    private val mapOverlayService: MapOverlayService,
+    private val locationService: LocationService
+) : ViewModel() {
+    private val _state = MutableStateFlow(
+        PhotoViewerState(stampState = StampState.Loading)
+    )
+    val state: StateFlow<PhotoViewerState> = _state
+
+    private var _stamp = MutableStateFlow<Stamp?>(null)
+    private var _event = MutableSharedFlow<MapEvent>()
+    var event : SharedFlow<MapEvent> = _event
+
+    private var _latestCamera = MutableStateFlow<CameraState?>(null)
+
+    val overlay = mapOverlayService.overlays
+    val fingerPrint = mapOverlayService.fingerPrintFlow
+
+    fun handleIntent(intent: PhotoViewerIntent) {
+        viewModelScope.launch(dispatcher) {
+            when (intent) {
+                is PhotoViewerIntent.Refresh -> refreshViewer(intent.photo)
+                is PhotoViewerIntent.Stamp -> stamp(intent.photo, intent.description)
+                is PhotoViewerIntent.RemoveStamp -> removeStamp(intent.photo)
+                is PhotoViewerIntent.CameraUpdate -> cameraUpdate(intent.camera)
+                is PhotoViewerIntent.LifecycleChange -> lifecycleChange(intent.event)
+            }
+        }
+    }
+
+    private fun cameraUpdate(camera: CameraState) {
+        _latestCamera.value = camera
+    }
+
+    suspend fun handleError(e: Throwable) {
+        handler.handle(e)
+    }
+
+    private suspend fun refreshViewer(photo: GalleryPhoto) {
+        val latestCamera = _latestCamera.value
+        val option = CameraOption.fromGalleryPhoto(photo)
+            ?.copy(zoom = ZOOM.DISTRICT.level, moveAnimation = MoveAnimation.APP_EASING)
+        val courseId = photo.courseId
+
+        if(option != null){
+            mapOverlayService.refreshSpot(option.latLng)
+            if (latestCamera != null) {
+                if (!locationService.isContainByViewPort(
+                        vp = latestCamera.viewport, target = option.latLng
+                    )
+                ) {
+                    _event.emit(MapEvent.MoveCamera(option))
+                }
+            }
+        }
+
+        if (courseId != null) {
+            withContext(Dispatchers.IO) {
+                getCourseUseCase(courseId)
+            }.onSuccess { course ->
+                mapOverlayService.refreshPath(course)
+            }
+
+            withContext(Dispatchers.IO) {
+                getStampUseCase(courseId)
+            }.onSuccess { stamp ->
+                if (stamp == null) {
+                    _stamp.update { null }
+                    _state.update {
+                        it.copy(
+                            stampProgress = StampProgress.Idle,
+                            stampState = StampState.Empty
+                        )
+                    }
+                } else {
+                    _stamp.update { stamp.copy(pickerId = photo.id) }
+                    _state.update {
+                        it.copy(
+                            stampProgress = StampProgress.Idle,
+                            stampState = StampState.Stamped(
+                                stampedAt = stamp.createAt,
+                                thumbnail = stamp.thumbnail,
+                                description = stamp.description
+                            )
+                        )
+                    }
+                }
+            }.onFailure {
+                _state.update { it.copy(stampProgress = StampProgress.Idle) }
+                handleError(it)
+            }
+        }
+    }
+
+    private suspend fun stamp(photo: GalleryPhoto, description: String?) {
+        val courseId = photo.courseId
+        val latlng = photo.exif.location
+        when {
+            _state.value.stampProgress != StampProgress.Idle -> return
+            courseId == null -> return
+            latlng == null -> return
+        }
+        _state.update {
+            it.copy(stampProgress = StampProgress.Stamping)
+        }
+
+        withContext(Dispatchers.IO) {
+            addCheckpointToCourseUseCase.stamp(
+                CheckPointContent(
+                    groupId = courseId,
+                    imageId = photo.imageId,
+                    latLng = latlng,
+                    description = description ?: ""
+                )
+            )
+        }.onSuccess {
+            refreshViewer(photo)
+        }.onFailure {
+            _state.update { it.copy(stampProgress = StampProgress.Idle) }
+            handleError(it)
+        }
+    }
+
+    private suspend fun removeStamp(photo: GalleryPhoto) {
+        if (_state.value.stampProgress != StampProgress.Idle) return
+        val stamp = _stamp.value ?: return
+        _state.update { it.copy(stampProgress = StampProgress.Removing) }
+
+        withContext(Dispatchers.IO) {
+            removeCheckPointUseCase.unStamp(stamp.id)
+        }.onSuccess {
+            refreshViewer(photo)
+        }.onFailure {
+            _state.update { it.copy(stampProgress = StampProgress.Idle) }
+            handleError(it)
+        }
+    }
+
+    private fun lifecycleChange(event: AppLifecycle) {
+        when(event){
+            AppLifecycle.onDispose -> {_latestCamera.value = null }
+            else -> {}
+        }
+    }
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -131,16 +131,16 @@
     <string name="account_valid_expire">계정 인증 만료, 로그인이 필요합니다.</string>
 
 
-    // 이미지 설명
+    <!-- 이미지 설명 -->
     <string name="google_logo">google logo</string>
 
-    // 메세지
+    <!-- 메세지 -->
     <string name="add_done">️📌 추가 완료.</string>
     <string name="remove_done">🗑 삭제 완료.</string>
     <string name="report_done">🚨 신고 완료.</string>
     <string name="retry_guide">잠시후 다시 시도해 주세요.</string>
 
-    // 가이드
+    <!-- 가이드 -->
     <string name="tutorial_start">🥳 반가워요, 같이 어디갈까를 둘러봐요!</string>
     <string name="tutorial_stop">🥺 튜토리얼은 다음에 다시 만나요.</string>
     <string name="welcome_start">새로운 시작을 환영해요\n아래에 정보를 눌러 코스를 확인하세요.</string>
@@ -156,11 +156,11 @@
 
     <string name="searchbar_guide_text">와인딩</string>
 
-    // 경고
+    <!-- 경고 -->
     <string name="warn_reason_inappropriate">부적절한 콘텐츠를 반복적으로 게시할 경우, 서비스 이용이 제한될 수 있습니다.</string>
     <string name="warn_reason_other">부적절한 사용이 계속되면 서비스 이용이 제한될 수 있습니다.</string>
 
-    // 차단
+    <!-- 차단 -->
     <string name="banned_user">이용이 제한된 사용자입니다</string>
     <string name="ban_reason_spam">정지: 스팸 또는 도배 행위 %s</string>
     <string name="ban_reason_abuse">정지: 욕설 또는 비하 발언 %s</string>
@@ -181,7 +181,7 @@
     <string name="report_copyright">저작권 침해</string>
     <string name="report_other">기타</string>
 
-    //오류
+    <!-- 오류 -->
     <string name="google_auth">구글 인증 오류</string>
     <string name="user_create_error">계정 생성 오류</string>
     <string name="unavailable_user">이용할 수 없는 계정 : %s</string>
@@ -193,7 +193,7 @@
 
     <string name="blank" />
 
-    // 사진 권한
+    <!-- 사진 권한 -->
     <string name="show_photo_select">선택한 사진 표시중</string>
     <string name="show_photo_select_desc">새로운 사진을 추가하려면 버튼을 클릭하세요.</string>
     <string name="need_photo_permission">사진을 불러오려면 접근 권한이 필요합니다</string>
@@ -205,7 +205,7 @@
     <string name="button_selected">선택됨</string>
     <string name="button_setting">설정</string>
 
-    // 갤러리
+    <!-- 갤러리 -->
     <string name="photo_delete_fail">사진을 삭제하지 못했어요</string>
     <string name="gallery_load_fail">사진을 불러오지 못했어요</string>
     <string name="media_save_fail">사진을 옮기지 못했어요</string>
@@ -222,12 +222,46 @@
     <string name="cancel">취소</string>
     <string name="how_show">어떻게 볼까요?</string>
     <string name="detail_info">상세 정보</string>
+    <string name="empty_gallery_question_title">혹시 코스에서 찍은 사진, 있지 않나요?</string>
+    <string name="empty_gallery_question_description">폰에 잠들어 있는 그 사진이면 충분해요.\n올리는 순간 코스를 알아서 찾아드려요.</string>
+    <string name="empty_gallery_find_in_gallery_button">갤러리에서 찾아보기</string>
+    <string name="empty_gallery_location_hint">위치 정보가 담긴 사진이면 바로 인식돼요</string>
 
+    <!-- 포토 뷰어 -->
+    <string name="not_yet_stamped_place">아직 도장을 안 찍은 곳</string>
+    <string name="num_visit">%1$s 방문</string>
+    <string name="swipe_to_pick_photo">스와이프해서 이곳을 대표할 사진을 고르세요.</string>
+    <string name="pick_this_photo">이 사진으로 게시 하기</string>
+    <string name="write_record_here">이곳에서의 기록을 남겨보세요.</string>
+    <string name="stamp_down">도장 찍기</string>
+    <string name="confirm_unstamp">도장을 내릴까요?</string>
+    <string name="record_removed_from_course">코스에 올린 기록이 내려가요. 사진과 기록은 내 기기에 그대로 남아요.</string>
+    <string name="unstamp">도장 내리기</string>
     <string-array name="gallery_loading">
+        <item>사진을 콕 집어 찾아오는 중…</item>
         <item>사진을 안전한 곳에 차곡차곡 담는 중…</item>
-        <item>위치 정보를 지우는중…</item>
-        <item>마지막 한 장까지 확인하는 중…</item>
+        <item>위치 정보를 지우는중…</item>작
         <item>사진을 사용하는 것에 대한 허락을 구하는 것을 묻는 것에 대한 승인을 요구하는중…</item>
     </string-array>
+    <string name="no_match_header_label">새 길의 시</string>
+    <string name="no_match_header_title">멋진 곳이었지만,\n코스는 아니었어요</string>
+    <string name="no_match_header_description">가까운 곳에서 다른 코스를 찾아보세요.</string>
+    <string name="no_location_status">위치 정보 없음</string>
+    <string name="no_location_transparency_title">위치 정보는 이렇게 쓰여요</string>
+    <string-array name="no_location_usage_chips">
+        <item>지도에 위치 표시</item>
+        <item>근처 코스 매칭</item>
+    </string-array>
+    <string name="no_location_reasons_title">이 사진에 위치가 없는 이유</string>
+    <string-array name="no_location_reasons">
+        <item>카메라 위치 태그가 꺼진 채 촬영됐어요</item>
+        <item>캡처·다운로드·메신저로 받은 사진이에요</item>
+        <item>촬영 앱에 위치 권한이 없었어요</item>
+    </string-array>
 
+    <string name="no_location_solution_title">다음 사진부터 저장하려면</string>
+    <string name="no_location_solution_body">카메라 설정에서 권한(위치)를 켜야해요.</string>
+
+    <string name="no_location_action_camera_settings">카메라 설정</string>
+    <string name="no_location_action_learn_more">더 알아보기</string>
 </resources>


### PR DESCRIPTION
### 1. 포토뷰어 스탬프
- 그룹화 된 사진을 페이지를 넘기며 탐색 할 수 있음
- 주소가 없는 사진은 권한 변경 안내 표시
- 코스가 없는 사진은 다른 코스 방문 유도 안내 표시
- 코스로 그룹화된 사진중 선택해 스탬프(체크포인트 추가)를 할 수 있음
- 스탬프 후에는 해당그룹에 포토뷰어에는 스탬프된 내용이 표시
- 기존 추가 방식(드라이브 화면)은 임시 비활성화


### 2. 갤러리 그룹화(코스별) 추가
- 코스별로 사진이 그룹화되어  표시
- 셀클릭시 셀의 그룹(코스별)이 함께 넘어감
- 로그인시 기기에서 가져오지 않아도 스탬프로 등록한 사진을 서버에서 갱신


## ✅ 테스트 항목
### 포토뷰어
- [x] 사진을 넘겨 탐색할수있는지 확인
- [x] 주소가 없는 사진일 경우 권한 변경 안내 표시가 되는지 확인
- [x] 코스가 없는 사진일 경우 다른코스 방문유도가 표시되는지 확인
- [x] 스탬프후 해당사진이 그룹대표 사진으로 표시되는지 확인
- [x] 스탬프 해제시 스탬프 버튼이 표시되는지 확인

### 갤러리
- [x] 그룹변경 선택창에서 “코스별” 선택시 코스별로 그룹화되어 표시되는지 확인
- [x] 사진 클릭시 포토뷰어에서 그룹화된 사진이 표시되는지 확인
- [x] 로그인후 기존에 추가된 체크포인트속 사진이 표시되는지 확인
- [x] 스탬프를 포함한 그룹 라벨 옆에 체크 아이콘이 표시되시되는지 확인

### 드라이브
- [x] 체크포인트 추가 플로팅 버튼이 숨겨졌는지 확인
