### PR TITLE
인디케이터 최대 표시갯수 제한

### DIFF
--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/MapPopup.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/MapPopup.kt
@@ -3,7 +3,6 @@ package com.wheretogo.presentation.composable.content
 import android.view.MotionEvent
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -18,11 +17,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -585,9 +582,10 @@ fun PopUpImageSlide(
                     .padding(horizontal = 12.dp, vertical = 10.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                SlideIndicator(
-                    currentIndex = pagerState.currentPage,
-                    totalCount = slideItems.size,
+                PageIndicator(
+                    pageCount = slideItems.size,
+                    currentPage = pagerState.currentPage,
+                    maxDotCount = 9,
                     modifier = Modifier.padding(bottom = 6.dp)
                 )
                 val item = slideItems.getOrNull(pagerState.currentPage)
@@ -633,38 +631,6 @@ private fun ImageCation(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun SlideIndicator(
-    currentIndex: Int,
-    totalCount: Int,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        repeat(totalCount) { index ->
-            val isActive = index == currentIndex
-            val width by animateDpAsState(
-                targetValue = if (isActive) 18.dp else 6.dp,
-                animationSpec = tween(durationMillis = 250),
-                label = "dot_width"
-            )
-            Box(
-                modifier = Modifier
-                    .height(6.dp)
-                    .width(width)
-                    .clip(CircleShape)
-                    .background(
-                        if (isActive) Palette.White
-                        else Palette.White.copy(alpha = 0.4f)
-                    )
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/NaverMapSheet.kt
@@ -333,6 +333,9 @@ private fun NaverMap.cameraUpdate(option: CameraOption) {
 private fun NaverMap.setMapStyle(style: NaverMapStyle) {
     mapType = style.mapType
 
+    maxZoom = style.maxZoom
+    minZoom = style.minZoom
+
     setLayerGroupEnabled(NaverMap.LAYER_GROUP_BUILDING, style.buildingEnabled)
     setLayerGroupEnabled(NaverMap.LAYER_GROUP_TRANSIT, style.transitEnabled)
     setLayerGroupEnabled(NaverMap.LAYER_GROUP_BICYCLE, style.bicycleEnabled)

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/content/PageIndicator.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/content/PageIndicator.kt
@@ -1,0 +1,65 @@
+package com.wheretogo.presentation.composable.content
+
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import com.wheretogo.presentation.theme.Palette
+
+@Composable
+fun PageIndicator(
+    pageCount: Int,
+    currentPage: Int,
+    maxDotCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    val half = maxDotCount / 2
+    val start = (currentPage - half)
+        .coerceIn(0, (pageCount - maxDotCount).coerceAtLeast(0))
+    val end = (start + maxDotCount).coerceAtMost(pageCount)
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        for (i in start until end) {
+            val isCurrent = i == currentPage
+            val isEdge = (i == start && start > 0) || (i == end - 1 && end < pageCount)
+
+            val width by animateDpAsState(
+                targetValue = if (isCurrent) 18.dp else 6.dp,
+                animationSpec = tween(250),
+                label = "dot_width"
+            )
+            val scale by animateFloatAsState(
+                targetValue = if (isEdge) 0.6f else 1f,
+                animationSpec = tween(250),
+                label = "dot_scale"
+            )
+
+            Box(
+                modifier = Modifier
+                    .graphicsLayer { scaleX = scale; scaleY = scale }
+                    .height(6.dp)
+                    .width(width)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(Palette.White)
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/photoviewer/PhotoViewerScreen.kt
@@ -5,27 +5,20 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -43,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -62,9 +54,9 @@ import coil.compose.AsyncImage
 import com.naver.maps.map.MapView
 import com.wheretogo.domain.model.gallery.GalleryPhoto
 import com.wheretogo.domain.model.gallery.PhotoExif
+import com.wheretogo.presentation.composable.content.PageIndicator
 import com.wheretogo.presentation.composable.effect.LifecycleDisposer
 import com.wheretogo.presentation.intent.PhotoViewerIntent
-import com.wheretogo.presentation.theme.Palette
 import com.wheretogo.presentation.viewmodel.PhotoViewerViewModel
 
 @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalFoundationApi::class)
@@ -165,6 +157,7 @@ fun PhotoViewerScreen(
                     PageIndicator(
                         pageCount = photos.size,
                         currentPage = pagerState.currentPage,
+                        maxDotCount = 11,
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
                             .padding(bottom = 12.dp),
@@ -212,36 +205,6 @@ fun PhotoViewerScreen(
                 .align(Alignment.TopStart),
         ) {
             Icon(Icons.Default.Close, null, tint = Color.White)
-        }
-    }
-}
-
-@Composable
-private fun PageIndicator(
-    pageCount: Int,
-    currentPage: Int,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        repeat(pageCount) { i ->
-            val isCurrent = i == currentPage
-            val width by animateDpAsState(
-                targetValue = if (isCurrent) 18.dp else 6.dp,
-                animationSpec = tween(durationMillis = 250),
-                label = "dot_width"
-            )
-            Box(
-                modifier = Modifier
-                    .height(6.dp)
-                    .width(width)
-                    .clip(if (isCurrent) RoundedCornerShape(3.dp) else CircleShape)
-                    .background(Palette.White)
-                ,
-            )
         }
     }
 }


### PR DESCRIPTION
### 1. 인디케이터 최대 표시갯수 제한
- 포토뷰어에서 최대갯수 제한(11)
- 이미지 팝업 에서 최대갯수 제한(9)

### 2. 최대/최소 줌 적용

## ✅ 테스트 항목
### 포토뷰어
- [x] 인디케이터가 최대 11개까지 표시되는지 확인

### 드라이브
- [x] 인디케이터가 최대 9개까지 표시되는지 확인
- [x] 확대/축소시 제한이 적용되는지 확인
