### PR TITLE
사진 선택창 UX 개선

### DIFF
--- a/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
@@ -3,6 +3,7 @@ package com.wheretogo.presentation.composable
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,11 +23,13 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -67,6 +70,7 @@ import com.wheretogo.presentation.viewmodel.MediaPickerUiEvent
 import com.wheretogo.presentation.viewmodel.MediaPickerViewModel
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MediaPicker(
     onPicked: (List<PickerImage>) -> Unit,
@@ -118,7 +122,7 @@ fun MediaPicker(
     LaunchedEffect(pagingItems.loadState) {
         val refresh = pagingItems.loadState.refresh
         val append = pagingItems.loadState.append
-        val error= when {
+        val error = when {
             refresh is LoadState.Error -> refresh.error
             append is LoadState.Error -> append.error
             else -> null
@@ -126,32 +130,45 @@ fun MediaPicker(
         error?.let { viewModel.handleError(it) }
     }
 
-    when (state.access) {
-        null -> DeniedView(
-            {
-                coroutine.launch {
-                    requestPermission(context, AppPermission.MEDIA)
-                }
-            },
-        )
-
-        MediaAccess.FULL,
-        MediaAccess.PARTIAL -> GalleryView(
-            access = state.access!!,
-            pagingItems = pagingItems,
-            selected = state.selected,
-            onToggle = viewModel::toggle,
-            onOpenPicker = {
-                coroutine.launch { requestPermission(context, AppPermission.MEDIA) }
-            },
-            onOpenSettings = {
-                coroutine.launch { openSetting(context, AppPermission.MEDIA) }
-            },
-            onConfirm = {
-                onPicked(it)
+    Scaffold(topBar = {
+        TopAppBar(title = { Text(stringResource(R.string.photo_select)) }, navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.Default.Close, contentDescription = null)
+            }
+        })
+    }, bottomBar = {
+        SelectBottomBar(
+            selectedSize = state.selected.size, onConfirm = {
+                val picked = (0 until pagingItems.itemCount).mapNotNull { pagingItems[it] }
+                    .filter { it.id in state.selected }
+                onPicked(picked)
                 onNavigateBack()
-            },
-        )
+            })
+    }) { padding ->
+        Box(Modifier.padding(padding)) {
+            when (state.access) {
+                null -> DeniedView(
+                    onRequestPermission = {
+                        coroutine.launch {
+                            requestPermission(context, AppPermission.MEDIA)
+                        }
+                    })
+
+                MediaAccess.FULL,
+                MediaAccess.PARTIAL -> GalleryView(
+                    access = state.access!!,
+                    pagingItems = pagingItems,
+                    selected = state.selected,
+                    onToggle = viewModel::toggle,
+                    onOpenPicker = {
+                        coroutine.launch { requestPermission(context, AppPermission.MEDIA) }
+                    },
+                    onOpenSettings = {
+                        coroutine.launch { openSetting(context, AppPermission.MEDIA) }
+                    },
+                )
+            }
+        }
     }
 }
 
@@ -176,7 +193,6 @@ private fun DeniedView(onRequestPermission: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GalleryView(
     access: MediaAccess,
@@ -184,67 +200,36 @@ private fun GalleryView(
     selected: Set<Long>,
     onToggle: (Long) -> Unit,
     onOpenPicker: () -> Unit,
-    onOpenSettings: () -> Unit,
-    onConfirm: (List<PickerImage>) -> Unit,
+    onOpenSettings: () -> Unit
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(stringResource(R.string.photo_select)) })
-        },
-        bottomBar = {
-            Surface(tonalElevation = 2.dp) {
-                Button(
-                    onClick = {
-                        val picked = (0 until pagingItems.itemCount)
-                            .mapNotNull { pagingItems[it] }
-                            .filter { it.id in selected }
-                        onConfirm(picked)
-                    },
-                    enabled = selected.isNotEmpty(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                ) {
-                    Text(stringResource(R.string.selected_count, selected.size))
-                }
-            }
-        },
-    ) { padding ->
-        Column(Modifier.padding(padding).background(
-            color = Palette.White100
-        )) {
-            when (access) {
-                MediaAccess.PARTIAL -> {
-                    AllowAllBanner(onOpenSettings)
-                    PartialBanner(onOpenPicker)
-                }
-                else -> {}
-            }
-
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(2.dp),
-            ) {
-                items(
-                    count = pagingItems.itemCount,
-                    key = { index -> pagingItems[index]?.id ?: index },
-                ) { index ->
-                    val image = pagingItems[index]
-                    if (image != null) {
-                        PhotoCell(
-                            image = image,
-                            isSelected = image.id in selected,
-                            onClick = { onToggle(image.id) },
-                        )
-                    } else {
-                        Box(
-                            Modifier
-                                .aspectRatio(1f)
-                                .padding(1.dp)
-                                .background(MaterialTheme.colorScheme.surfaceVariant),
-                        )
-                    }
+    Column {
+        if (access == MediaAccess.PARTIAL) {
+            AllowAllBanner(onOpenSettings)
+            PartialBanner(onOpenPicker)
+        }
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(2.dp),
+        ) {
+            items(
+                count = pagingItems.itemCount,
+                key = { index -> pagingItems[index]?.id ?: index },
+            ) { index ->
+                val image = pagingItems[index]
+                if (image != null) {
+                    PhotoCell(
+                        image = image,
+                        isSelected = image.id in selected,
+                        onClick = { onToggle(image.id) },
+                    )
+                } else {
+                    Box(
+                        Modifier
+                            .aspectRatio(1f)
+                            .padding(1.dp)
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                    )
                 }
             }
         }
@@ -360,16 +345,28 @@ private fun PhotoCell(
     }
 }
 
-private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier =
-    this.then(
-        Modifier.clickable(
-            interactionSource = mutableStateOf(
-                androidx.compose.foundation.interaction.MutableInteractionSource()
-            ).value,
-            indication = null,
-            onClick = onClick,
-        )
+@Composable
+fun SelectBottomBar(selectedSize: Int, onConfirm: () -> Unit) {
+    Surface(tonalElevation = 2.dp) {
+        Button(
+            onClick = onConfirm,
+            enabled = selectedSize > 0,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(stringResource(R.string.selected_count, selectedSize))
+        }
+    }
+}
+
+private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier = this.then(
+    Modifier.clickable(
+        interactionSource = mutableStateOf(MutableInteractionSource()).value,
+        indication = null,
+        onClick = onClick,
     )
+)
 
 @Composable
 private fun fakePagingItems(count: Int): LazyPagingItems<PickerImage> {
@@ -389,7 +386,6 @@ private fun GalleryViewFullPreview() {
             onToggle = {},
             onOpenPicker = {},
             onOpenSettings = {},
-            onConfirm = {},
         )
     }
 }
@@ -405,7 +401,14 @@ private fun GalleryViewPartialPreview() {
             onToggle = {},
             onOpenPicker = {},
             onOpenSettings = {},
-            onConfirm = {},
         )
+    }
+}
+
+@Preview(showBackground = true, name = "DENIED")
+@Composable
+private fun DeniedViewPreview() {
+    WhereTogoTheme {
+        DeniedView(onRequestPermission = {})
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/MediaPicker.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
@@ -203,6 +204,7 @@ private fun GalleryView(
     onOpenSettings: () -> Unit
 ) {
     Column {
+        PickPhotoBanner()
         if (access == MediaAccess.PARTIAL) {
             AllowAllBanner(onOpenSettings)
             PartialBanner(onOpenPicker)
@@ -232,6 +234,40 @@ private fun GalleryView(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PickPhotoBanner() {
+    val tint = Palette.TealBanner
+    Surface(
+        color = tint.copy(alpha = 0.12f),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(20.dp))
+                    .size(15.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AutoAwesome,
+                    contentDescription = null,
+                    tint= tint
+                )
+            }
+            Spacer(modifier = Modifier.width(7.dp))
+            Text(
+                stringResource(R.string.course_found_app),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.weight(1f),
+                color = tint
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleryScreen.kt
@@ -81,6 +81,7 @@ import com.wheretogo.presentation.intent.GalleryIntent
 import com.wheretogo.presentation.model.PhotoSection
 import com.wheretogo.presentation.state.GalleryState
 import com.wheretogo.presentation.viewmodel.GalleryFlowViewModel
+import kotlinx.coroutines.delay
 
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -99,17 +100,8 @@ fun GalleryScreen(
 
 
     LaunchedEffect(Unit) {
+        delay(200)
         viewModel.handleIntent(GalleryIntent.Initialize(openPicker))
-    }
-
-    if (showPicker==true) {
-        MediaPicker(
-            onPicked = { picked ->
-                viewModel.handleIntent(GalleryIntent.MediaPicked(picked))
-            },
-            onNavigateBack = { viewModel.handleIntent(GalleryIntent.DismissPicker) },
-        )
-        return
     }
 
     val state = uiState
@@ -128,9 +120,11 @@ fun GalleryScreen(
             }
         },
     ) { padding ->
-        Box(Modifier
-            .fillMaxSize()
-            .padding(padding)) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
             Column(Modifier.fillMaxSize()) {
 
                 if (state is GalleryState.Success) {
@@ -154,18 +148,22 @@ fun GalleryScreen(
                     when (state) {
                         is GalleryState.Loading ->
                             LoadingMessageScreen()
+
                         is GalleryState.Error ->
-                            Column(Modifier.align(Alignment.Center), horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(state.message)
-                                TextButton(
-                                    onClick = { viewModel.handleIntent(GalleryIntent.Refresh) }
-                                ) { Text(stringResource(R.string.retry)) }
-                            }
-                        is GalleryState.Empty -> EmptyGalleryScreen(
-                            onFindInGalleryClick = {
-                                viewModel.handleIntent(GalleryIntent.PhotoAddClick)
-                            }
-                        )
+                            GalleryErrorScreen(
+                                message = state.message,
+                                onRetryButtonClick = {
+                                    viewModel.handleIntent(GalleryIntent.Refresh)
+                                }
+                            )
+
+                        is GalleryState.Empty ->
+                            EmptyGalleryScreen(
+                                onFindInGalleryClick = {
+                                    viewModel.handleIntent(GalleryIntent.PhotoAddClick)
+                                }
+                            )
+
                         is GalleryState.Success ->
                             PhotoGrid(
                                 sections = state.sections,
@@ -202,6 +200,19 @@ fun GalleryScreen(
                 )
             }
         }
+    }
+
+    AnimatedVisibility(
+        visible = showPicker == true,
+        enter = slideInVertically { it } + fadeIn(),
+        exit = slideOutVertically { it } + fadeOut(),
+    ) {
+        MediaPicker(
+            onPicked = { picked ->
+                viewModel.handleIntent(GalleryIntent.MediaPicked(picked))
+            },
+            onNavigateBack = { viewModel.handleIntent(GalleryIntent.DismissPicker) },
+        )
     }
 
     if (showGroupingSheet) {

--- a/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleyErrorScreen.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/composable/gallery/GalleyErrorScreen.kt
@@ -1,0 +1,27 @@
+package com.wheretogo.presentation.composable.gallery
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.wheretogo.presentation.R
+
+@Composable
+fun GalleryErrorScreen(message: String, onRetryButtonClick:()->Unit) {
+    Box(modifier = Modifier.fillMaxSize()){
+        Column(
+            Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(message)
+            TextButton(
+                onClick =  onRetryButtonClick
+            ) { Text(stringResource(R.string.retry)) }
+        }
+    }
+}

--- a/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/theme/Color.kt
@@ -31,6 +31,8 @@ object Palette {
     val Teal200 = Color(0xFF03DAC5)
     val Teal700 = Color(0xFF018786)
 
+    val TealBanner = Color(0xFF1D9E75)
+
     // Green
     val Green50 = Color(0xFFCCE8CC)
     val Green100 = Color(0xFFB9D7B9)

--- a/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
+++ b/presentation/src/main/java/com/wheretogo/presentation/viewmodel/GalleryFlowViewModel.kt
@@ -83,7 +83,6 @@ class GalleryFlowViewModel @Inject constructor(
 
     init {
         observeGalleryPhotos()
-        handleIntent(GalleryIntent.Refresh)
     }
 
     private fun observeGalleryPhotos() {
@@ -200,6 +199,7 @@ class GalleryFlowViewModel @Inject constructor(
     }
 
     private fun initialize(openPicker: Boolean) {
+        handleIntent(GalleryIntent.Refresh)
         if(_pickerVisible.value == null && openPicker)
             _pickerVisible.value = true
     }

--- a/presentation/src/main/res/values-en/strings.xml
+++ b/presentation/src/main/res/values-en/strings.xml
@@ -195,6 +195,7 @@
     <string name="show_photo_select_desc">Tap the button to add more photos.</string>
     <string name="need_photo_permission">Photo access is required to load your photos</string>
     <string name="need_all_photo_permission">To see all your photos, allow full access in Settings.</string>
+    <string name="course_found_app">사진속 코스를 알아서 찾아줘요.</string>
     <string name="need_permission">Grant permission</string>
     <string name="more_add">Add more</string>
     <string name="photo_select">Select photos</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="show_photo_select_desc">새로운 사진을 추가하려면 버튼을 클릭하세요.</string>
     <string name="need_photo_permission">사진을 불러오려면 접근 권한이 필요합니다</string>
     <string name="need_all_photo_permission">전체 사진을 보려면 설정에서 접근 권한을 허용하세요.</string>
+    <string name="course_found_app">사진속 코스를 알아서 찾아줘요.</string>
     <string name="need_permission">권한 요청</string>
     <string name="more_add">더 추가</string>
     <string name="photo_select">사진 선택</string>


### PR DESCRIPTION
### 1. 그룹화 안내배너 추가
- 창 상단 배너로 표시

### 2. 창 표시 에니메이션 추가
- 슬라이드 + 페이드
- 연속 이동시 에니메이션 사이 딜레이

## ✅ 테스트 항목
- [x] 사진 선택창 상단에 그룹화 안내배너 표시 확인
- [x] 갤러리뷰에서 사진선택 버튼 클릭시 에니메이션 확인
- [x] 홈에서 연속 이동시 일정 딜레이가 지나서 창이 표시되는지 확인
